### PR TITLE
Multiquery groundwork

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,7 +306,8 @@ fn implement<A: Allocate, T: Timestamp+Lattice>(
     rules: Vec<Rule>,
     mut publish: Vec<String>,
     scope: &mut Child<Worker<A>, T>,
-    ctx: &mut Context<T>
+    ctx: &mut Context<T>,
+    probe: &mut ProbeHandle<Product<RootTimestamp, T>>,
 ) -> HashMap<String, RelationHandle<T>> {
 
     let db = &mut ctx.db;
@@ -347,6 +348,7 @@ fn implement<A: Allocate, T: Timestamp+Lattice>(
                 relation
                     .variable
                     .leave()
+                    .probe_with(probe)
                     .arrange_by_self()
                     .trace;
 
@@ -679,9 +681,10 @@ pub fn register<A: Allocate, T: Timestamp+Lattice>(
     // plan: Plan,
     rules: Vec<Rule>,
     publish: Vec<String>,
+    probe: &mut ProbeHandle<Product<RootTimestamp, T>>,
 ) -> HashMap<String, RelationHandle<T>> {
 
-    let result_map = implement(rules, publish, scope, ctx);
+    let result_map = implement(rules, publish, scope, ctx, probe);
 
     // @TODO store trace somewhere for re-use from other queries later
     // queries.insert(name.clone(), output_collection.arrange_by_self().trace);


### PR DESCRIPTION
This PR lays the groundwork for multiple queries in the same request, by generalizing `implement` to support publishing multiple named relations. Rather than have a distinguished query and many supporting rules, implementation is done against a batch of rules and a set of identifiers to publish.

```rust
fn implement<A: Allocate, T: Timestamp+Lattice>(
    // name: &String,
    // plan: Plan,
    rules: Vec<Rule>,
    mut publish: Vec<String>,
    scope: &mut Child<Worker<A>, T>,
    ctx: &mut Context<T>
) -> HashMap<String, RelationHandle<T>> {
```

The method now creates a `NamedRelation` for each rule, creates public traces for each published name, implements each rule, and then binds each to their definition.

In `server.rs`, we translate traditional queries like so

```rust
    // let mut rel_map = register(scope, &mut ctx, &query_name, plan, rules);
    rules.push(Rule { name: query_name.clone(), plan: plan });
    let mut rel_map = register(scope, &mut ctx, rules, vec![query_name.clone()]);
```

This should be ready (modulo bugs) to support requests that publish multiple rules, thought this may need to be decoupled from registering interest in a query (getting results back).