### PR TITLE
Function expression plan extension

### DIFF
--- a/src/plan/transform.rs
+++ b/src/plan/transform.rs
@@ -26,7 +26,7 @@ pub enum Function {
 pub struct Transform<P: Implementable> {
     /// TODO
     pub variables: Vec<Var>,
-    /// Variable containing the result binded by the transformation
+    /// Symbol to which the result of the transformation is bound
     pub result_sym: Var,
     /// Plan for the data source
     pub plan: Box<P>,

--- a/src/plan/transform.rs
+++ b/src/plan/transform.rs
@@ -26,7 +26,9 @@ pub enum Function {
 pub struct Transform<P: Implementable> {
     /// TODO
     pub variables: Vec<Var>,
-    /// Plan for the data source.
+    /// Variable containing the result binded by the transformation
+    pub result_sym: Var,
+    /// Plan for the data source
     pub plan: Box<P>,
     /// Function to apply
     pub function: Function,
@@ -52,9 +54,12 @@ impl<P: Implementable> Implementable for Transform<P> {
             })
             .collect();
 
+        let mut symbols = rel.symbols().to_vec().clone();
+        symbols.push(self.result_sym);
+        
         match self.function {
             Function::INTERVAL => SimpleRelation {
-                symbols: rel.symbols().to_vec(),
+                symbols: symbols,
                 tuples: rel.tuples().map(move |tuple| {
                     let mut t = match tuple[key_offsets[0]] {
                         Value::Instant(inst) => inst as u64,
@@ -63,7 +68,7 @@ impl<P: Implementable> Implementable for Transform<P> {
                     // @TODO Add parameter to control the interval
                     t = t - (t % 3600000);
                     let mut v = tuple.clone();
-                    v[key_offsets[0]] = Value::Instant(t);
+                    v.push(Value::Instant(t));
                     v
                 }),
             },

--- a/tests/transform_test.rs
+++ b/tests/transform_test.rs
@@ -16,10 +16,11 @@ fn interval() {
         let mut server = Server::new(Default::default());
         let (send_results, results) = channel();
 
-        // [:find ?t :where [?e :timestamp ?t] [(interval ?t) ?t]]
-        let (e, t) = (1, 2);
+        // [:find ?h :where [?e :timestamp ?t] [(interval ?t) ?h]]
+        let (e, t, h) = (1, 2, 3);
         let plan = Plan::Transform(Transform {
             variables: vec![t],
+            result_sym: h,
             plan: Box::new(Plan::MatchA(e, ":timestamp".to_string(), t)),
             function: Function::INTERVAL,
         });
@@ -87,11 +88,11 @@ fn interval() {
         thread::spawn(move || {
             assert_eq!(
                 results.recv().unwrap(),
-                (vec![Value::Eid(1), Value::Instant(1540047600000)], 1)
+                (vec![Value::Eid(1), Value::Instant(1540048515500), Value::Instant(1540047600000)], 1)
             );
             assert_eq!(
                 results.recv().unwrap(),
-                (vec![Value::Eid(2), Value::Instant(1540047600000)], 1)
+                (vec![Value::Eid(2), Value::Instant(1540048515616), Value::Instant(1540047600000)], 1)
             );
         }).join()
             .unwrap();


### PR DESCRIPTION
- The `Transform` struct takes a `result_sym` var
- Transformations append into the Value vector
- Append the result_sym into the created `SimpleRelation` symbols s.t. later plans can properly order 