### PR TITLE
Extend function expressions to enable constant bindings

### DIFF
--- a/src/plan/transform.rs
+++ b/src/plan/transform.rs
@@ -74,7 +74,7 @@ impl<P: Implementable> Implementable for Transform<P> {
                     let interval_param = match constants_local.get(&1){  
                         Some(Value::String(interval)) => interval as &String, 
                         None => &default_interval,
-                        _ => panic!("Paramter for TRUNCATE must be a string"),
+                        _ => panic!("Parameter for TRUNCATE must be a string"),
                     };
                     let interval_options = vec![String::from("minute"), String::from("hour"), String::from("day"), String::from("week")];
                     let millies : Vec<u64> = vec![60000, 3600000, 86400000, 604800000];

--- a/tests/transform_test.rs
+++ b/tests/transform_test.rs
@@ -3,6 +3,7 @@ extern crate timely;
 
 use std::sync::mpsc::channel;
 use std::thread;
+use std::collections::HashMap;
 
 use timely::Configuration;
 
@@ -18,11 +19,14 @@ fn interval() {
 
         // [:find ?h :where [?e :timestamp ?t] [(interval ?t) ?h]]
         let (e, t, h) = (1, 2, 3);
+        let mut constants = HashMap::new();
+        // constants.insert(1, Value::String(String::from("hour")));
         let plan = Plan::Transform(Transform {
             variables: vec![t],
             result_sym: h,
             plan: Box::new(Plan::MatchA(e, ":timestamp".to_string(), t)),
             function: Function::INTERVAL,
+            constants: constants
         });
 
         worker.dataflow::<u64, _, _>(|mut scope| {

--- a/tests/transform_test.rs
+++ b/tests/transform_test.rs
@@ -25,7 +25,7 @@ fn truncate() {
             variables: vec![t],
             result_sym: h,
             plan: Box::new(Plan::MatchA(e, ":timestamp".to_string(), t)),
-            function: Function::INTERVAL,
+            function: Function::TRUNCATE,
             constants: constants
         });
 

--- a/tests/transform_test.rs
+++ b/tests/transform_test.rs
@@ -12,7 +12,7 @@ use declarative_dataflow::server::{CreateInput, Interest, Register, Server, Tran
 use declarative_dataflow::{Plan, Rule, Value};
 
 #[test]
-fn interval() {
+fn truncate() {
     timely::execute(Configuration::Thread, move |worker| {
         let mut server = Server::new(Default::default());
         let (send_results, results) = channel();
@@ -37,7 +37,7 @@ fn interval() {
                 &mut scope,
             );
 
-            let query_name = "interval";
+            let query_name = "truncate";
             server.register(
                 Register {
                     rules: vec![Rule {


### PR DESCRIPTION
- Extend current built in fn truncate with different constant values