### PR TITLE
Additional function expression

### DIFF
--- a/src/plan/transform.rs
+++ b/src/plan/transform.rs
@@ -79,12 +79,12 @@ impl<P: Implementable> Implementable for Transform<P> {
                 symbols: symbols,
                 tuples: rel.tuples().map(move |tuple| {
                     let mut t = match tuple[key_offsets[0]] {
-                        Value::Instant(inst) => inst as u64,
-                        _ => panic!("TRUNCATE can only be applied to timestamps"),
+                        Value::Number(num) => num as i64,
+                        _ => panic!("TRUNCATE can only be applied to numbers"),
                     };
                     let default_interval = String::from(":hour");
-                    let interval_param = match constants_local.get(&1){  
-                        Some(Value::String(interval)) => interval as &String, 
+                    let interval_param = match constants_local.get(&1) {
+                        Some(Value::String(interval)) => interval as &String,
                         None => &default_interval,
                         _ => panic!("Parameter for TRUNCATE must be a string"),
                     };
@@ -94,12 +94,12 @@ impl<P: Implementable> Implementable for Transform<P> {
                         ":hour" => 3600000,
                         ":day" => 86400000,
                         ":week" => 604800000,
-                        _ => panic!("Unknown interval for TRUNCATE") 
+                        _ => panic!("Unknown interval for TRUNCATE"),
                     };
 
                     t = t - (t % mod_val);
                     let mut v = tuple.clone();
-                    v.push(Value::Instant(t));
+                    v.push(Value::Number(t));
                     v
                 }),
             },

--- a/tests/transform_test.rs
+++ b/tests/transform_test.rs
@@ -17,10 +17,10 @@ fn truncate() {
         let mut server = Server::new(Default::default());
         let (send_results, results) = channel();
 
-        // [:find ?h :where [?e :timestamp ?t] [(interval ?t) ?h]]
+        // [:find ?e ?t ?h :where [?e :timestamp ?t] [(truncate ?t) ?h]]
         let (e, t, h) = (1, 2, 3);
         let mut constants = HashMap::new();
-        // constants.insert(1, Value::String(String::from("hour")));
+        constants.insert(1, Value::String(String::from(":hour")));
         let plan = Plan::Transform(Transform {
             variables: vec![t],
             result_sym: h,
@@ -55,18 +55,8 @@ fn truncate() {
             Transact {
                 tx: Some(0),
                 tx_data: vec![
-                    TxData(
-                        1,
-                        1,
-                        ":timestamp".to_string(),
-                        Value::Instant(1540048515500),
-                    ),
-                    TxData(
-                        1,
-                        2,
-                        ":timestamp".to_string(),
-                        Value::Instant(1540048515616),
-                    ),
+                    TxData(1, 1, ":timestamp".to_string(), Value::Number(1540048515500)),
+                    TxData(1, 2, ":timestamp".to_string(), Value::Number(1540048515616)),
                 ],
             },
             0,
@@ -78,11 +68,25 @@ fn truncate() {
         thread::spawn(move || {
             assert_eq!(
                 results.recv().unwrap(),
-                (vec![Value::Eid(1), Value::Instant(1540048515500), Value::Instant(1540047600000)], 1)
+                (
+                    vec![
+                        Value::Eid(1),
+                        Value::Number(1540048515500),
+                        Value::Number(1540047600000),
+                    ],
+                    1
+                )
             );
             assert_eq!(
                 results.recv().unwrap(),
-                (vec![Value::Eid(2), Value::Instant(1540048515616), Value::Instant(1540047600000)], 1)
+                (
+                    vec![
+                        Value::Eid(2),
+                        Value::Number(1540048515616),
+                        Value::Number(1540047600000),
+                    ],
+                    1
+                )
             );
         }).join()
             .unwrap();


### PR DESCRIPTION
- Add BIND function expression to be able to add a constant value into a queries result set
```
[:find ?u ?l
:where
[?e :user ?u]
[(bind "all" ?u) ?l]]
```

- Change truncates values to Number for now
- Update test accordingly