### PR TITLE
Add datomics with functionality

### DIFF
--- a/src/plan/aggregate.rs
+++ b/src/plan/aggregate.rs
@@ -51,6 +51,8 @@ pub struct Aggregate<P: Implementable> {
     pub key_symbols: Vec<Var>,
     /// Aggregation symbols
     pub aggregation_symbols: Vec<Var>,
+    /// With symbols
+    pub with_symbols: Vec<Var>,
 }
 
 impl<P: Implementable> Implementable for Aggregate<P> {
@@ -102,68 +104,61 @@ impl<P: Implementable> Implementable for Aggregate<P> {
         // resulting collections, s.t. they can be joined afterwards.
         for (i, aggregation_fn) in self.aggregation_fns.iter().enumerate() {
             let value_offset = value_offsets[i];
+            let with_lenght = self.with_symbols.len();
+
+            // Access the right value for the given iteration loop and extend possible with-values.
+            let prepare_unary = move |(key, tuple): (Vec<Value>, Vec<Value>)| {
+                let value = &tuple[value_offset];
+                let mut v = vec![value.clone()];
+
+                // With-symbols are always the last elements in the value part of each tuple, given they are specified.
+                // We append these, s.t. we consolidate correctly.
+                // @TODO I'm not sure if the compiler is smart enough to skip the iteration if `with-lenght` is zero
+                v.extend(tuple.iter().rev().take(with_lenght).cloned());
+
+                (key, v)
+            };
 
             match aggregation_fn {
                 AggregationFn::MIN =>  {
                     let tuples = tuples
-                        .map(move |(key, tuple)| {
-                            let v = match tuple[value_offset] {
-                                Value::Number(num) => num,
-                                _ => panic!("MIN can only be applied on type Number."),
-                            };
-                            (key, v)
-                        })
+                        .map(prepare_unary)
                         .group(|_key, vals, output| {
-                            let min = vals[0].0;
-                            output.push((*min, 1));
+                            let min = &vals[0].0[0];
+                            output.push((min.clone(), 1));
                         })
                         .map(move |(key, min)| {
-                            (key, vec![Value::Number(min as i64)])
+                            (key, vec![min])
                         });
                     collections.push(tuples);
                 },
                 AggregationFn::MAX => {
                     let tuples = tuples
-                        .map(move |(key, tuple)| {
-                            let v = match tuple[value_offset] {
-                                Value::Number(num) => num,
-                                _ => panic!("MAX can only be applied on type Number."),
-                            };
-                            (key, v)
-                        })
+                        .map(prepare_unary)
                         .group(|_key, vals, output| {
-                            let max = vals[vals.len() - 1].0;
-                            output.push((*max, 1));
+                            let max = &vals[vals.len() - 1].0[0];
+                            output.push((max.clone(), 1));
                         })
                         .map(move |(key, max)| {
-                            (key, vec![Value::Number(max as i64)])
+                            (key, vec![max])
                         });
                     collections.push(tuples);
                 },
                 AggregationFn::MEDIAN =>  {
                     let tuples = tuples
-                        .map(move |(key, tuple)| {
-                            let v = match tuple[value_offset] {
-                                Value::Number(num) => num,
-                                _ => panic!("MEDIAN can only be applied on type Number."),
-                            };
-                            (key, v)
-                        })
+                        .map(prepare_unary)
                         .group(|_key, vals, output| {
-                            let median = vals[vals.len() / 2].0;
-                            output.push((*median, 1));
+                            let median = &vals[vals.len() / 2].0[0];
+                            output.push((median.clone(), 1));
                         })
                         .map(move |(key, med)| {
-                            (key, vec![Value::Number(med as i64)])
+                            (key, vec![med])
                         });
                     collections.push(tuples);
                 },
                 AggregationFn::COUNT =>  {
                     let tuples = tuples
-                        .map(move |(key, tuple)| {
-                            let v = tuple[value_offset].clone() ;
-                            (key, v)
-                        })
+                        .map(prepare_unary)
                         .group(|_key, input, output| output.push((input.len(), 1)))
                         .map(move |(key, count)| {
                             (key, vec![Value::Number(count as i64)])
@@ -172,17 +167,15 @@ impl<P: Implementable> Implementable for Aggregate<P> {
                 },
                 AggregationFn::SUM =>  {
                     let tuples = tuples
-                        .map(move |(key, tuple)| {
-                            let v = match tuple[value_offset] {
-                                Value::Number(num) => num,
-                                _ => panic!("MEDIAN can only be applied on type Number."),
-                            };
-                            (key, v)
-                        })
+                        .map(prepare_unary)
                         .consolidate()
                         .distinct()
                         .explode(|(key, val)| {
-                            Some((key, val as isize))
+                            let v = match val[0] {
+                                Value::Number(num) => num,
+                                _ => panic!("SUM can only be applied on type Number."),
+                            };
+                            Some((key, v as isize))
                         })
                         .count()
                         .map(move |(key, count)| {
@@ -192,17 +185,15 @@ impl<P: Implementable> Implementable for Aggregate<P> {
                 },
                 AggregationFn::AVG =>  {
                     let tuples = tuples
-                        .map(move |(key, tuple)| {
-                            let v = match tuple[value_offset] {
-                                Value::Number(num) => num,
-                                _ => panic!("MEDIAN can only be applied on type Number."),
-                            };
-                            (key, v)
-                        })
+                        .map(prepare_unary)
                         .consolidate()
                         .distinct()
                         .explode(move |(key, val)| {
-                            Some((key, DiffPair::new(val as isize, 1)))
+                            let v = match val[0] {
+                                Value::Number(num) => num,
+                                _ => panic!("AVG can only be applied on type Number."),
+                            };
+                            Some((key, DiffPair::new(v as isize, 1)))
                         })
                         .count()
                         .map(move |(key, diff_pair)| {
@@ -214,17 +205,15 @@ impl<P: Implementable> Implementable for Aggregate<P> {
                 },
                 AggregationFn::VARIANCE => {
                     let tuples = tuples
-                        .map(move |(key, tuple)| {
-                            let v = match tuple[value_offset] {
-                                Value::Number(num) => num,
-                                _ => panic!("MEDIAN can only be applied on type Number."),
-                            };
-                            (key, v)
-                        })
+                        .map(prepare_unary)
                         .consolidate()
                         .distinct()
                         .explode(move |(key, val)| {
-                            Some((key, DiffPair::new(DiffPair::new(val as isize * val as isize, val as isize), 1)))
+                            let v = match val[0] {
+                                Value::Number(num) => num,
+                                _ => panic!("VARIANCE can only be applied on type Number."),
+                            };
+                            Some((key, DiffPair::new(DiffPair::new(v as isize * v as isize, v as isize), 1)))
                         })
                         .count()
                         .map(move |(key, diff_pair)| {

--- a/src/plan/aggregate.rs
+++ b/src/plan/aggregate.rs
@@ -89,11 +89,11 @@ impl<P: Implementable> Implementable for Aggregate<P> {
         // the correct output offset for each aggregation.
         
         let mut variables = self.variables.clone();
-        let mut output_positions = Vec::new();
-        
+        let mut output_offsets = Vec::new();
+
         for sym in self.aggregation_symbols.iter() {
             let output_index = variables.iter().position(|&v| *sym == v).unwrap();
-            output_positions.push(output_index);
+            output_offsets.push(output_index);
 
             variables[output_index] = 0;
         }
@@ -229,14 +229,14 @@ impl<P: Implementable> Implementable for Aggregate<P> {
         }
 
         if collections.len() == 1 {
-            let output_position = output_positions[0];
+            let output_index = output_offsets[0];
             SimpleRelation{
                 symbols: self.variables.to_vec(),
                 tuples: collections[0]
                     .map(move |(key, val)| {
                         let mut k = key.clone();
                         let v = val[0].clone();
-                        k.insert(output_position, v);
+                        k.insert(output_index, v);
                         k
                     })
             }
@@ -256,7 +256,7 @@ impl<P: Implementable> Implementable for Aggregate<P> {
                 tuples: tuples.map(move |(key, vals)|{
                     let mut v = key.clone();
                     for (i, val) in vals.iter().enumerate(){
-                        v.insert(output_positions[i], val.clone())
+                        v.insert(output_offsets[i], val.clone())
                     }
                     v
                 })

--- a/src/plan/aggregate.rs
+++ b/src/plan/aggregate.rs
@@ -104,7 +104,7 @@ impl<P: Implementable> Implementable for Aggregate<P> {
         // resulting collections, s.t. they can be joined afterwards.
         for (i, aggregation_fn) in self.aggregation_fns.iter().enumerate() {
             let value_offset = value_offsets[i];
-            let with_lenght = self.with_symbols.len();
+            let with_length = self.with_symbols.len();
 
             // Access the right value for the given iteration loop and extend possible with-values.
             let prepare_unary = move |(key, tuple): (Vec<Value>, Vec<Value>)| {
@@ -113,8 +113,9 @@ impl<P: Implementable> Implementable for Aggregate<P> {
 
                 // With-symbols are always the last elements in the value part of each tuple, given they are specified.
                 // We append these, s.t. we consolidate correctly.
-                // @TODO I'm not sure if the compiler is smart enough to skip the iteration if `with-lenght` is zero
-                v.extend(tuple.iter().rev().take(with_lenght).cloned());
+                if with_length > 0 {
+                    v.extend(tuple.iter().rev().take(with_length).cloned());
+                }
 
                 (key, v)
             };

--- a/tests/aggregation_test.rs
+++ b/tests/aggregation_test.rs
@@ -30,6 +30,7 @@ fn count() {
             aggregation_fns: vec![AggregationFn::COUNT],
             key_symbols: vec![],
             aggregation_symbols: vec![amount],
+            with_symbols: vec![],
         });
 
         // [:find ?e (count ?amount) :where [?e :amount ?amount]]
@@ -50,6 +51,7 @@ fn count() {
             aggregation_fns: vec![AggregationFn::COUNT],
             key_symbols: vec![e, amount],
             aggregation_symbols: vec![amount],
+            with_symbols: vec![],
         });
 
         worker.dataflow::<u64, _, _>(|mut scope| {
@@ -181,6 +183,7 @@ fn max() {
             aggregation_fns: vec![AggregationFn::MAX],
             key_symbols: vec![],
             aggregation_symbols: vec![amount],
+            with_symbols: vec![],
         });
 
         // [:find ?e (max ?amount) :where [?e :amount ?amount]]
@@ -190,6 +193,7 @@ fn max() {
             aggregation_fns: vec![AggregationFn::MAX],
             key_symbols: vec![e],
             aggregation_symbols: vec![amount],
+            with_symbols: vec![],
         });
 
         worker.dataflow::<u64, _, _>(|mut scope| {
@@ -283,6 +287,7 @@ fn min() {
             aggregation_fns: vec![AggregationFn::MIN],
             key_symbols: vec![],
             aggregation_symbols: vec![amount],
+            with_symbols: vec![],
         });
 
         // [:find ?e (min ?amount) :where [?e :amount ?amount]]
@@ -292,6 +297,7 @@ fn min() {
             aggregation_fns: vec![AggregationFn::MIN],
             key_symbols: vec![e],
             aggregation_symbols: vec![amount],
+            with_symbols: vec![],
         });
 
         worker.dataflow::<u64, _, _>(|mut scope| {
@@ -385,6 +391,7 @@ fn sum() {
             aggregation_fns: vec![AggregationFn::SUM],
             key_symbols: vec![],
             aggregation_symbols: vec![amount],
+            with_symbols: vec![],
         });
 
         // [:find ?e (sum ?amount) :where [?e :amount ?amount]]
@@ -394,6 +401,7 @@ fn sum() {
             aggregation_fns: vec![AggregationFn::SUM],
             key_symbols: vec![e],
             aggregation_symbols: vec![amount],
+            with_symbols: vec![],
         });
 
         worker.dataflow::<u64, _, _>(|mut scope| {
@@ -487,6 +495,7 @@ fn avg() {
             aggregation_fns: vec![AggregationFn::AVG],
             key_symbols: vec![],
             aggregation_symbols: vec![amount],
+            with_symbols: vec![],
         });
 
         // [:find ?e (avg ?amount) :where [?e :amount ?amount]]
@@ -496,6 +505,7 @@ fn avg() {
             aggregation_fns: vec![AggregationFn::AVG],
             key_symbols: vec![e],
             aggregation_symbols: vec![amount],
+            with_symbols: vec![],
         });
 
         worker.dataflow::<u64, _, _>(|mut scope| {
@@ -698,6 +708,7 @@ fn median() {
             aggregation_fns: vec![AggregationFn::MEDIAN],
             key_symbols: vec![],
             aggregation_symbols: vec![amount],
+            with_symbols: vec![],
         });
 
         // [:find ?e (median ?amount) :where [?e :amount ?amount]]
@@ -707,6 +718,7 @@ fn median() {
             aggregation_fns: vec![AggregationFn::MEDIAN],
             key_symbols: vec![e],
             aggregation_symbols: vec![amount],
+            with_symbols: vec![],
         });
 
         worker.dataflow::<u64, _, _>(|mut scope| {
@@ -811,6 +823,7 @@ fn multi() {
             ],
             key_symbols: vec![],
             aggregation_symbols: vec![amount, debt, amount, debt],
+            with_symbols: vec![],
         });
 
         // [:find ?e (min ?amount) (max ?amount) (median ?amount) (count ?amount) (min ?debt)
@@ -837,6 +850,7 @@ fn multi() {
             ],
             key_symbols: vec![e],
             aggregation_symbols: vec![amount, amount, amount, amount, debt, debt, debt, debt],
+            with_symbols: vec![],
         });
 
         worker.dataflow::<u64, _, _>(|mut scope| {

--- a/tests/aggregation_test.rs
+++ b/tests/aggregation_test.rs
@@ -20,13 +20,15 @@ fn count() {
         let mut server = Server::new(Default::default());
         let (send_results, results) = channel();
         let send_results_copy = send_results.clone();
-        let send_results_copy_2 = send_results.clone();
 
         // [:find (count ?amount) :where [?e :amount ?amount]]
         let (e, amount) = (1, 2);
         let plan = Plan::Aggregate(Aggregate {
             variables: vec![amount],
-            plan: Box::new(Plan::MatchA(e, ":amount".to_string(), amount)),
+            plan: Box::new(Plan::Project(Project {
+                variables: vec![amount],
+                plan: Box::new(Plan::MatchA(e, ":amount".to_string(), amount)),
+            })),
             aggregation_fns: vec![AggregationFn::COUNT],
             key_symbols: vec![],
             aggregation_symbols: vec![amount],
@@ -35,21 +37,11 @@ fn count() {
 
         // [:find ?e (count ?amount) :where [?e :amount ?amount]]
         let (e, amount) = (1, 2);
-        let plan_group_sing = Plan::Aggregate(Aggregate {
+        let plan_group= Plan::Aggregate(Aggregate {
             variables: vec![e, amount],
             plan: Box::new(Plan::MatchA(e, ":amount".to_string(), amount)),
             aggregation_fns: vec![AggregationFn::COUNT],
             key_symbols: vec![e],
-            aggregation_symbols: vec![amount],
-        });
-
-        // [:find ?e ?amount (count ?amount) :where [?e :amount ?amount]]
-        let (e, amount) = (1, 2);
-        let plan_group_mult = Plan::Aggregate(Aggregate {
-            variables: vec![e, amount],
-            plan: Box::new(Plan::MatchA(e, ":amount".to_string(), amount)),
-            aggregation_fns: vec![AggregationFn::COUNT],
-            key_symbols: vec![e, amount],
             aggregation_symbols: vec![amount],
             with_symbols: vec![],
         });
@@ -75,12 +67,12 @@ fn count() {
                     send_results.send((x.0.clone(), x.2)).unwrap();
                 });
 
-            let query_name = "count_group_single_key";
+            let query_name = "count_group";
             server.register(
                 Register {
                     rules: vec![Rule {
                         name: query_name.to_string(),
-                        plan: plan_group_sing,
+                        plan: plan_group,
                     }],
                     publish: vec![query_name.to_string()],
                 },
@@ -93,23 +85,6 @@ fn count() {
                     send_results_copy.send((x.0.clone(), x.2)).unwrap();
                 });
 
-            let query_name = "count_group_multiple_keys";
-            server.register(
-                Register {
-                    rules: vec![Rule {
-                        name: query_name.to_string(),
-                        plan: plan_group_mult,
-                    }],
-                    publish: vec![query_name.to_string()],
-                },
-                &mut scope,
-            );
-
-            server
-                .interest(query_name.to_string(), &mut scope)
-                .inspect(move |x| {
-                    send_results_copy_2.send((x.0.clone(), x.2)).unwrap();
-                });
         });
 
         server.transact(
@@ -131,7 +106,6 @@ fn count() {
         worker.step_while(|| server.is_any_outdated());
 
         thread::spawn(move || {
-            assert_eq!(results.recv().unwrap(), (vec![Value::Number(5)], 1));
             assert_eq!(
                 results.recv().unwrap(),
                 (vec![Value::Eid(1), Value::Number(4)], 1)
@@ -140,26 +114,7 @@ fn count() {
                 results.recv().unwrap(),
                 (vec![Value::Eid(2), Value::Number(1)], 1)
             );
-            assert_eq!(
-                results.recv().unwrap(),
-                (vec![Value::Eid(1), Value::Number(2), Value::Number(1)], 1)
-            );
-            assert_eq!(
-                results.recv().unwrap(),
-                (vec![Value::Eid(1), Value::Number(4), Value::Number(1)], 1)
-            );
-            assert_eq!(
-                results.recv().unwrap(),
-                (vec![Value::Eid(1), Value::Number(5), Value::Number(1)], 1)
-            );
-            assert_eq!(
-                results.recv().unwrap(),
-                (vec![Value::Eid(1), Value::Number(6), Value::Number(1)], 1)
-            );
-            assert_eq!(
-                results.recv().unwrap(),
-                (vec![Value::Eid(2), Value::Number(10), Value::Number(1)], 1)
-            );
+            assert_eq!(results.recv().unwrap(), (vec![Value::Number(5)], 1));
         }).join()
             .unwrap();
     }).unwrap();


### PR DESCRIPTION
- The frontend will project the specified with-symbols as last elements. That means if there are n with-symbols we simply need to take the last n elements of the value part of each tuple and append it before consolidating to ensure the correct semantics. 
- This process is incorporated into a `prepare_unary` closure that every aggregation first maps to its differential collection. 
- This will lead to the same behaviour as datomics `:with` clause