### PR TITLE
Bitemporal

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -44,6 +44,9 @@ type T = u64;
 #[cfg(feature = "real-time")]
 type T = Duration;
 
+// use declarative_dataflow::timestamp::pair::Pair;
+// type T = Pair<Duration, u64>;
+
 const SERVER: Token = Token(usize::MAX - 1);
 const RESULTS: Token = Token(usize::MAX - 2);
 const TENANT_RESULTS: Token = Token(usize::MAX - 3);

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -114,6 +114,7 @@ fn main() {
         let mut server = Server::<T, Token>::new_at(config.clone(), worker.timer());
 
         if config.enable_logging {
+            #[cfg(feature = "real-time")]
             server.enable_logging(worker).unwrap();
         }
 
@@ -817,6 +818,7 @@ fn main() {
         drop(sequencer);
 
         // Shutdown loggers s.t. logging dataflows can shut down.
+        #[cfg(feature = "real-time")]
         server.shutdown_logging(worker).unwrap();
 
     }).expect("Timely computation did not exit cleanly");

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -3,9 +3,8 @@
 
 use std::collections::HashMap;
 
-use timely::dataflow::operators::UnorderedInput;
+use timely::dataflow::operators::{Probe, UnorderedInput};
 use timely::dataflow::{ProbeHandle, Scope, ScopeParent, Stream};
-use timely::order::TotalOrder;
 use timely::progress::frontier::AntichainRef;
 use timely::progress::Timestamp;
 
@@ -99,7 +98,7 @@ where
             Ok(())
         }
     }
-    
+
     /// Creates an attribute that can be transacted upon by clients.
     pub fn create_transactable_attribute<S: Scope<Timestamp = T>>(
         &mut self,
@@ -107,13 +106,13 @@ where
         config: AttributeConfig,
         scope: &mut S,
     ) -> Result<(), Error> {
-        let (session, pairs) = {
+        let pairs = {
             let ((handle, cap), pairs) = scope.new_unordered_input::<((Value, Value), T, isize)>();
             let session = UnorderedSession::from(handle, cap);
 
             self.input_sessions.insert(name.to_string(), session);
 
-            (session, pairs)
+            pairs
         };
 
         // We do not want to probe transactable attributes, because

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -64,10 +64,7 @@ where
         name: &str,
         config: AttributeConfig,
         scope: &mut S,
-    ) -> Result<(), Error>
-    where
-        T: TotalOrder,
-    {
+    ) -> Result<(), Error> {
         if self.forward.contains_key(name) {
             Err(Error {
                 category: "df.error.category/conflict",

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -74,12 +74,12 @@ where
                 message: format!("An attribute of name {} already exists.", name),
             })
         } else {
-            let ((handle, cap), tuples) = scope.new_unordered_input::<((Value, Value), T, isize)>();
+            let ((handle, cap), pairs) = scope.new_unordered_input::<((Value, Value), T, isize)>();
             let session = UnorderedSession::from(handle, cap);
 
             self.input_sessions.insert(name.to_string(), session);
 
-            self.create_sourced_attribute(name, config, &tuples)?;
+            self.create_sourced_attribute(name, config, &pairs)?;
 
             Ok(())
         }

--- a/src/domain/unordered_session.rs
+++ b/src/domain/unordered_session.rs
@@ -1,10 +1,13 @@
-//! Input sessions for unordered collection updates.
+//! Translation of Differential's input sessions to unordered
+//! collection updates.
 //!
-//! Although users can directly manipulate timely dataflow streams as collection inputs,
-//! the `UnorderedSession` type can make this more efficient and less error-prone. Specifically,
-//! the type batches up updates with their logical times and ships them with coarsened
-//! timely dataflow capabilities, exposing more concurrency to the operator implementations
-//! than are evident from the logical times, which appear to execute in sequence.
+//! Although users can directly manipulate timely dataflow streams as
+//! collection inputs, the `UnorderedSession` type can make this more
+//! efficient and less error-prone. Specifically, the type batches up
+//! updates with their logical times and ships them with coarsened
+//! timely dataflow capabilities, exposing more concurrency to the
+//! operator implementations than are evident from the logical times,
+//! which appear to execute in sequence.
 
 use timely::dataflow::operators::unordered_input::{ActivateCapability, UnorderedHandle};
 use timely::progress::Timestamp;
@@ -14,53 +17,12 @@ use differential_dataflow::Data;
 
 /// An input session wrapping a single timely dataflow capability.
 ///
-/// Each timely dataflow message has a corresponding capability, which is a logical time in the
-/// timely dataflow system. Differential dataflow updates can happen at a much higher rate than
-/// timely dataflow's progress tracking infrastructure supports, because the logical times are
-/// promoted to data and updates are batched together. The `UnorderedSession` type does this batching.
-///
-/// # Examples
-///
-/// ```
-/// extern crate timely;
-/// extern crate differential_dataflow;
-///
-/// use timely::Configuration;
-/// use differential_dataflow::input::Input;
-///
-/// fn main() {
-///     ::timely::execute(Configuration::Thread, |worker| {
-///
-///			let (mut handle, probe) = worker.dataflow(|scope| {
-///				// create input handle and collection.
-///				let (handle, data) = scope.new_collection_from(0 .. 10);
-///         	let probe = data.map(|x| x * 2)
-///				            	.inspect(|x| println!("{:?}", x))
-///				            	.probe();
-///				(handle, probe)
-///     	});
-///
-///			handle.insert(3);
-///			handle.advance_to(1);
-///			handle.insert(5);
-///			handle.advance_to(2);
-///			handle.flush();
-///
-///			while probe.less_than(handle.time()) {
-///				worker.step();
-///			}
-///
-///			handle.remove(5);
-///			handle.advance_to(3);
-///			handle.flush();
-///
-///			while probe.less_than(handle.time()) {
-///				worker.step();
-///			}
-///
-///		}).unwrap();
-/// }
-/// ```
+/// Each timely dataflow message has a corresponding capability, which
+/// is a logical time in the timely dataflow system. Differential
+/// dataflow updates can happen at a much higher rate than timely
+/// dataflow's progress tracking infrastructure supports, because the
+/// logical times are promoted to data and updates are batched
+/// together. The `InputSession` type does this batching.
 pub struct UnorderedSession<T: Timestamp + Clone, D: Data, R: Monoid> {
     time: T,
     cap: ActivateCapability<T>,

--- a/src/domain/unordered_session.rs
+++ b/src/domain/unordered_session.rs
@@ -1,0 +1,154 @@
+//! Input sessions for unordered collection updates.
+//!
+//! Although users can directly manipulate timely dataflow streams as collection inputs,
+//! the `UnorderedSession` type can make this more efficient and less error-prone. Specifically,
+//! the type batches up updates with their logical times and ships them with coarsened
+//! timely dataflow capabilities, exposing more concurrency to the operator implementations
+//! than are evident from the logical times, which appear to execute in sequence.
+
+use timely::dataflow::operators::unordered_input::{ActivateCapability, UnorderedHandle};
+use timely::progress::Timestamp;
+
+use differential_dataflow::difference::Monoid;
+use differential_dataflow::Data;
+
+/// An input session wrapping a single timely dataflow capability.
+///
+/// Each timely dataflow message has a corresponding capability, which is a logical time in the
+/// timely dataflow system. Differential dataflow updates can happen at a much higher rate than
+/// timely dataflow's progress tracking infrastructure supports, because the logical times are
+/// promoted to data and updates are batched together. The `UnorderedSession` type does this batching.
+///
+/// # Examples
+///
+/// ```
+/// extern crate timely;
+/// extern crate differential_dataflow;
+///
+/// use timely::Configuration;
+/// use differential_dataflow::input::Input;
+///
+/// fn main() {
+///     ::timely::execute(Configuration::Thread, |worker| {
+///
+///			let (mut handle, probe) = worker.dataflow(|scope| {
+///				// create input handle and collection.
+///				let (handle, data) = scope.new_collection_from(0 .. 10);
+///         	let probe = data.map(|x| x * 2)
+///				            	.inspect(|x| println!("{:?}", x))
+///				            	.probe();
+///				(handle, probe)
+///     	});
+///
+///			handle.insert(3);
+///			handle.advance_to(1);
+///			handle.insert(5);
+///			handle.advance_to(2);
+///			handle.flush();
+///
+///			while probe.less_than(handle.time()) {
+///				worker.step();
+///			}
+///
+///			handle.remove(5);
+///			handle.advance_to(3);
+///			handle.flush();
+///
+///			while probe.less_than(handle.time()) {
+///				worker.step();
+///			}
+///
+///		}).unwrap();
+/// }
+/// ```
+pub struct UnorderedSession<T: Timestamp + Clone, D: Data, R: Monoid> {
+    cap: ActivateCapability<T>,
+    buffer: Vec<(D, T, R)>,
+    handle: UnorderedHandle<T, (D, T, R)>,
+}
+
+impl<T: Timestamp + Clone, D: Data, R: Monoid> UnorderedSession<T, D, R> {
+    /// Creates a new session from a reference to an input handle.
+    pub fn from(handle: UnorderedHandle<T, (D, T, R)>, cap: ActivateCapability<T>) -> Self {
+        UnorderedSession {
+            cap,
+            buffer: Vec::new(),
+            handle,
+        }
+    }
+
+    /// Adds to the weight of an element in the collection.
+    pub fn update(&mut self, element: D, change: R) {
+        if self.buffer.len() == self.buffer.capacity() {
+            if self.buffer.len() > 0 {
+                self.handle
+                    .session(self.cap.clone())
+                    .give_iterator(self.buffer.drain(..));
+            }
+            // TODO : This is a fairly arbitrary choice; should probably use `Context::default_size()` or such.
+            self.buffer.reserve(1024);
+        }
+        self.buffer.push((element, self.cap.time().clone(), change));
+    }
+
+    /// Adds to the weight of an element in the collection at a future time.
+    pub fn update_at(&mut self, element: D, time: T, change: R) {
+        assert!(self.cap.time().less_equal(&time));
+        if self.buffer.len() == self.buffer.capacity() {
+            if self.buffer.len() > 0 {
+                self.handle
+                    .session(self.cap.clone())
+                    .give_iterator(self.buffer.drain(..));
+            }
+            // TODO : This is a fairly arbitrary choice; should probably use `Context::default_size()` or such.
+            self.buffer.reserve(1024);
+        }
+        self.buffer.push((element, time, change));
+    }
+
+    /// Forces buffered data into the timely dataflow input, and
+    /// advances its time to match that of the session.
+    ///
+    /// It is important to call `flush` before expecting timely
+    /// dataflow to report progress. Until this method is called, all
+    /// updates may still be in internal buffers and not exposed to
+    /// timely dataflow. Once the method is called, all buffers are
+    /// flushed and timely dataflow is advised that some logical times
+    /// are no longer possible.
+    pub fn flush(&mut self) {
+        // @TODO get rid of the double buffering maybe?
+        self.handle
+            .session(self.cap.clone())
+            .give_iterator(self.buffer.drain(..));
+    }
+
+    /// Advances the logical time for future records.
+    ///
+    /// Importantly, this method does **not** immediately inform
+    /// timely dataflow of the change. This happens only when the
+    /// session is dropped or flushed. It is not correct to use this
+    /// time as a basis for a computation's `step_while` method unless
+    /// the session has just been flushed.
+    #[inline]
+    pub fn advance_to(&mut self, time: T) {
+        self.cap = self.cap.delayed(&time);
+    }
+
+    /// Reveals the current time of the session.
+    pub fn epoch(&self) -> &T {
+        &self.cap.time()
+    }
+    /// Reveals the current time of the session.
+    pub fn time(&self) -> &T {
+        &self.cap.time()
+    }
+
+    /// Closes the input, flushing and sealing the wrapped timely input.
+    pub fn close(self) {}
+}
+
+impl<T: Timestamp + Clone, D: Data, R: Monoid> Drop for UnorderedSession<T, D, R> {
+    fn drop(&mut self) {
+        self.flush();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -611,7 +611,7 @@ pub struct CollectionRelation<'a, G: Scope> {
 
 impl<'a, G: Scope> AsBinding for CollectionRelation<'a, G>
 where
-    G::Timestamp: Lattice + Data + TotalOrder,
+    G::Timestamp: Lattice + Data,
 {
     fn variables(&self) -> Vec<Var> {
         self.variables.clone()
@@ -735,7 +735,7 @@ where
 impl<'a, G, I> Relation<'a, G, I> for AttributeBinding
 where
     G: Scope,
-    G::Timestamp: Lattice + Data + TotalOrder,
+    G::Timestamp: Lattice + Data,
     I: ImplContext<G::Timestamp>,
 {
     fn tuples(
@@ -848,7 +848,7 @@ where
 
 impl<'a, G: Scope> AsBinding for Implemented<'a, G>
 where
-    G::Timestamp: Lattice + Data + TotalOrder,
+    G::Timestamp: Lattice + Data,
 {
     fn variables(&self) -> Vec<Var> {
         match self {
@@ -884,7 +884,7 @@ where
 impl<'a, G, I> Relation<'a, G, I> for Implemented<'a, G>
 where
     G: Scope,
-    G::Timestamp: Lattice + Data + TotalOrder,
+    G::Timestamp: Lattice + Data,
     I: ImplContext<G::Timestamp>,
 {
     fn tuples(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ use std::time::Duration;
 use timely::dataflow::operators::CapabilitySet;
 use timely::dataflow::scopes::child::{Child, Iterative};
 use timely::dataflow::*;
-use timely::order::{Product, TotalOrder};
+use timely::order::Product;
 use timely::progress::timestamp::Refines;
 use timely::progress::Timestamp;
 
@@ -561,7 +561,7 @@ pub struct Rule {
 trait Relation<'a, G, I>: AsBinding
 where
     G: Scope,
-    G::Timestamp: Lattice + Data + TotalOrder,
+    G::Timestamp: Lattice + Data,
     I: ImplContext<G::Timestamp>,
 {
     /// A collection containing all tuples.
@@ -633,7 +633,7 @@ where
 impl<'a, G, I> Relation<'a, G, I> for CollectionRelation<'a, G>
 where
     G: Scope,
-    G::Timestamp: Lattice + Data + TotalOrder,
+    G::Timestamp: Lattice + Data,
     I: ImplContext<G::Timestamp>,
 {
     fn tuples(
@@ -964,7 +964,7 @@ pub fn q(target_variables: Vec<Var>, bindings: Vec<Binding>) -> Plan {
 /// the specified names. Includes the specified names.
 pub fn collect_dependencies<T, I>(context: &I, names: &[&str]) -> Result<Vec<Rule>, Error>
 where
-    T: Timestamp + Lattice + TotalOrder,
+    T: Timestamp + Lattice,
     I: ImplContext<T>,
 {
     let mut seen = HashSet::new();
@@ -1034,7 +1034,7 @@ pub fn implement<T, I, S>(
     Error,
 >
 where
-    T: Timestamp + Lattice + TotalOrder + Default,
+    T: Timestamp + Lattice + Default,
     I: ImplContext<T>,
     S: Scope<Timestamp = T>,
 {
@@ -1138,7 +1138,7 @@ pub fn implement_neu<T, I, S>(
     Error,
 >
 where
-    T: Timestamp + Lattice + TotalOrder + Default,
+    T: Timestamp + Lattice + Default,
     I: ImplContext<T>,
     S: Scope<Timestamp = T>,
 {

--- a/src/plan/aggregate.rs
+++ b/src/plan/aggregate.rs
@@ -2,7 +2,6 @@
 
 use timely::dataflow::scopes::child::Iterative;
 use timely::dataflow::Scope;
-use timely::order::TotalOrder;
 use timely::progress::Timestamp;
 
 use differential_dataflow::difference::DiffPair;
@@ -72,7 +71,7 @@ impl<P: Implementable> Implementable for Aggregate<P> {
         context: &mut I,
     ) -> (Implemented<'b, S>, ShutdownHandle)
     where
-        T: Timestamp + Lattice + TotalOrder,
+        T: Timestamp + Lattice,
         I: ImplContext<T>,
         S: Scope<Timestamp = T>,
     {

--- a/src/plan/aggregate_neu.rs
+++ b/src/plan/aggregate_neu.rs
@@ -2,7 +2,6 @@
 
 use timely::dataflow::scopes::child::Iterative;
 use timely::dataflow::Scope;
-use timely::order::TotalOrder;
 use timely::progress::Timestamp;
 
 use differential_dataflow::difference::DiffPair;
@@ -72,7 +71,7 @@ impl<P: Implementable> Implementable for Aggregate<P> {
         context: &mut I,
     ) -> (Implemented<'b, S>, ShutdownHandle)
     where
-        T: Timestamp + Lattice + TotalOrder,
+        T: Timestamp + Lattice,
         I: ImplContext<T>,
         S: Scope<Timestamp = T>,
     {

--- a/src/plan/antijoin.rs
+++ b/src/plan/antijoin.rs
@@ -2,7 +2,6 @@
 
 use timely::dataflow::scopes::child::Iterative;
 use timely::dataflow::Scope;
-use timely::order::TotalOrder;
 use timely::progress::Timestamp;
 
 use differential_dataflow::lattice::Lattice;
@@ -52,7 +51,7 @@ impl<P1: Implementable, P2: Implementable> Implementable for Antijoin<P1, P2> {
         context: &mut I,
     ) -> (Implemented<'b, S>, ShutdownHandle)
     where
-        T: Timestamp + Lattice + TotalOrder,
+        T: Timestamp + Lattice,
         I: ImplContext<T>,
         S: Scope<Timestamp = T>,
     {

--- a/src/plan/filter.rs
+++ b/src/plan/filter.rs
@@ -2,7 +2,6 @@
 
 use timely::dataflow::scopes::child::Iterative;
 use timely::dataflow::Scope;
-use timely::order::TotalOrder;
 use timely::progress::Timestamp;
 
 use differential_dataflow::lattice::Lattice;
@@ -78,7 +77,7 @@ impl<P: Implementable> Implementable for Filter<P> {
         context: &mut I,
     ) -> (Implemented<'b, S>, ShutdownHandle)
     where
-        T: Timestamp + Lattice + TotalOrder,
+        T: Timestamp + Lattice,
         I: ImplContext<T>,
         S: Scope<Timestamp = T>,
     {

--- a/src/plan/hector.rs
+++ b/src/plan/hector.rs
@@ -14,7 +14,7 @@ use timely::dataflow::channels::pact::{Exchange, Pipeline};
 use timely::dataflow::operators::{Concatenate, Operator, Partition};
 use timely::dataflow::scopes::child::Iterative;
 use timely::dataflow::Scope;
-use timely::order::{Product, TotalOrder};
+use timely::order::Product;
 use timely::progress::Timestamp;
 use timely::worker::AsWorker;
 use timely::PartialOrder;
@@ -484,7 +484,7 @@ impl Implementable for Hector {
         context: &mut I,
     ) -> (Implemented<'b, S>, ShutdownHandle)
     where
-        T: Timestamp + Lattice + TotalOrder,
+        T: Timestamp + Lattice,
         I: ImplContext<T>,
         S: Scope<Timestamp = T>,
     {

--- a/src/plan/hector.rs
+++ b/src/plan/hector.rs
@@ -334,7 +334,7 @@ impl Hector {
         context: &mut I,
     ) -> (Implemented<'b, S>, ShutdownHandle)
     where
-        T: Timestamp + Lattice + TotalOrder,
+        T: Timestamp + Lattice,
         I: ImplContext<T>,
         S: Scope<Timestamp = T>,
     {

--- a/src/plan/join.rs
+++ b/src/plan/join.rs
@@ -2,7 +2,6 @@
 
 use timely::dataflow::scopes::child::Iterative;
 use timely::dataflow::Scope;
-use timely::order::Product;
 use timely::progress::Timestamp;
 
 use differential_dataflow::lattice::Lattice;

--- a/src/plan/join.rs
+++ b/src/plan/join.rs
@@ -2,7 +2,7 @@
 
 use timely::dataflow::scopes::child::Iterative;
 use timely::dataflow::Scope;
-use timely::order::{Product, TotalOrder};
+use timely::order::Product;
 use timely::progress::Timestamp;
 
 use differential_dataflow::lattice::Lattice;
@@ -39,7 +39,7 @@ fn attribute_attribute<'b, T, I, S>(
     right: AttributeBinding,
 ) -> (Implemented<'b, S>, ShutdownHandle)
 where
-    T: Timestamp + Lattice + TotalOrder,
+    T: Timestamp + Lattice,
     I: ImplContext<T>,
     S: Scope<Timestamp = T>,
 {
@@ -129,7 +129,7 @@ fn collection_collection<'b, T, S, I>(
     right: CollectionRelation<'b, S>,
 ) -> (Implemented<'b, S>, ShutdownHandle)
 where
-    T: Timestamp + Lattice + TotalOrder,
+    T: Timestamp + Lattice,
     I: ImplContext<T>,
     S: Scope<Timestamp = T>,
 {
@@ -192,7 +192,7 @@ fn collection_attribute<'b, T, S, I>(
     right: AttributeBinding,
 ) -> (Implemented<'b, S>, ShutdownHandle)
 where
-    T: Timestamp + Lattice + TotalOrder,
+    T: Timestamp + Lattice,
     I: ImplContext<T>,
     S: Scope<Timestamp = T>,
 {
@@ -322,7 +322,7 @@ impl<P1: Implementable, P2: Implementable> Implementable for Join<P1, P2> {
         context: &mut I,
     ) -> (Implemented<'b, S>, ShutdownHandle)
     where
-        T: Timestamp + Lattice + TotalOrder,
+        T: Timestamp + Lattice,
         I: ImplContext<T>,
         S: Scope<Timestamp = T>,
     {

--- a/src/plan/join.rs
+++ b/src/plan/join.rs
@@ -2,6 +2,7 @@
 
 use timely::dataflow::scopes::child::Iterative;
 use timely::dataflow::Scope;
+use timely::order::Product;
 use timely::progress::Timestamp;
 
 use differential_dataflow::lattice::Lattice;

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{self, AtomicUsize};
 
 use timely::dataflow::scopes::child::Iterative;
 use timely::dataflow::Scope;
-use timely::order::{Product, TotalOrder};
+use timely::order::Product;
 use timely::progress::Timestamp;
 
 use differential_dataflow::lattice::Lattice;
@@ -63,7 +63,7 @@ pub fn gensym() -> Var {
 /// implementation of plans.
 pub trait ImplContext<T>
 where
-    T: Timestamp + Lattice + TotalOrder,
+    T: Timestamp + Lattice,
 {
     /// Returns the definition for the rule of the given name.
     fn rule(&self, name: &str) -> Option<&Rule>;
@@ -167,7 +167,7 @@ pub trait Implementable {
         context: &mut I,
     ) -> (Implemented<'b, S>, ShutdownHandle)
     where
-        T: Timestamp + Lattice + TotalOrder,
+        T: Timestamp + Lattice,
         I: ImplContext<T>,
         S: Scope<Timestamp = T>;
 }
@@ -331,7 +331,7 @@ impl Implementable for Plan {
         context: &mut I,
     ) -> (Implemented<'b, S>, ShutdownHandle)
     where
-        T: Timestamp + Lattice + TotalOrder,
+        T: Timestamp + Lattice,
         I: ImplContext<T>,
         S: Scope<Timestamp = T>,
     {

--- a/src/plan/project.rs
+++ b/src/plan/project.rs
@@ -2,7 +2,6 @@
 
 use timely::dataflow::scopes::child::Iterative;
 use timely::dataflow::Scope;
-use timely::order::TotalOrder;
 use timely::progress::Timestamp;
 
 use differential_dataflow::lattice::Lattice;
@@ -54,7 +53,7 @@ impl<P: Implementable> Implementable for Project<P> {
         context: &mut I,
     ) -> (Implemented<'b, S>, ShutdownHandle)
     where
-        T: Timestamp + Lattice + TotalOrder,
+        T: Timestamp + Lattice,
         I: ImplContext<T>,
         S: Scope<Timestamp = T>,
     {

--- a/src/plan/pull.rs
+++ b/src/plan/pull.rs
@@ -3,7 +3,7 @@
 use timely::dataflow::operators::Concatenate;
 use timely::dataflow::scopes::child::Iterative;
 use timely::dataflow::Scope;
-use timely::order::{Product, TotalOrder};
+use timely::order::Product;
 use timely::progress::Timestamp;
 
 use differential_dataflow::lattice::Lattice;
@@ -85,7 +85,7 @@ impl<P: Implementable> Implementable for PullLevel<P> {
         context: &mut I,
     ) -> (Implemented<'b, S>, ShutdownHandle)
     where
-        T: Timestamp + Lattice + TotalOrder,
+        T: Timestamp + Lattice,
         I: ImplContext<T>,
         S: Scope<Timestamp = T>,
     {
@@ -196,7 +196,7 @@ impl<P: Implementable> Implementable for Pull<P> {
         context: &mut I,
     ) -> (Implemented<'b, S>, ShutdownHandle)
     where
-        T: Timestamp + Lattice + TotalOrder,
+        T: Timestamp + Lattice,
         I: ImplContext<T>,
         S: Scope<Timestamp = T>,
     {

--- a/src/plan/transform.rs
+++ b/src/plan/transform.rs
@@ -2,7 +2,6 @@
 
 use timely::dataflow::scopes::child::Iterative;
 use timely::dataflow::Scope;
-use timely::order::TotalOrder;
 use timely::progress::Timestamp;
 
 use differential_dataflow::lattice::Lattice;
@@ -56,7 +55,7 @@ impl<P: Implementable> Implementable for Transform<P> {
         context: &mut I,
     ) -> (Implemented<'b, S>, ShutdownHandle)
     where
-        T: Timestamp + Lattice + TotalOrder,
+        T: Timestamp + Lattice,
         I: ImplContext<T>,
         S: Scope<Timestamp = T>,
     {

--- a/src/plan/union.rs
+++ b/src/plan/union.rs
@@ -2,7 +2,6 @@
 
 use timely::dataflow::scopes::child::Iterative;
 use timely::dataflow::Scope;
-use timely::order::TotalOrder;
 use timely::progress::Timestamp;
 
 use differential_dataflow::lattice::Lattice;
@@ -48,7 +47,7 @@ impl<P: Implementable> Implementable for Union<P> {
         context: &mut I,
     ) -> (Implemented<'b, S>, ShutdownHandle)
     where
-        T: Timestamp + Lattice + TotalOrder,
+        T: Timestamp + Lattice,
         I: ImplContext<T>,
         S: Scope<Timestamp = T>,
     {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -473,7 +473,6 @@ where
             Ok(relation) => relation.probe_with(&mut self.probe),
         }
     }
-}
 
 impl<Token> Server<Duration, Token>
 where

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -10,7 +10,6 @@ use timely::communication::Allocate;
 use timely::dataflow::operators::capture::event::link::EventLink;
 use timely::dataflow::{ProbeHandle, Scope};
 use timely::logging::{BatchLogger, Logger, TimelyEvent};
-use timely::order::TotalOrder;
 use timely::progress::Timestamp;
 use timely::worker::Worker;
 
@@ -473,6 +472,7 @@ where
             Ok(relation) => relation.probe_with(&mut self.probe),
         }
     }
+}
 
 impl<Token> Server<Duration, Token>
 where
@@ -493,6 +493,7 @@ where
             .insert::<DifferentialEvent, _>("differential/arrange", move |time, data| {
                 differential_logger.publish_batch(time, data)
             });
+
         Ok(())
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -138,7 +138,7 @@ pub enum Request {
 /// input handles.
 pub struct Server<T, Token>
 where
-    T: Timestamp + Lattice + TotalOrder,
+    T: Timestamp + Lattice,
     Token: Hash + Eq + Copy,
 {
     /// Server configuration.
@@ -169,7 +169,7 @@ where
 /// Implementation context.
 pub struct Context<T>
 where
-    T: Timestamp + Lattice + TotalOrder,
+    T: Timestamp + Lattice,
 {
     /// Representation of named rules.
     pub rules: HashMap<Aid, Rule>,
@@ -181,7 +181,7 @@ where
 
 impl<T> ImplContext<T> for Context<T>
 where
-    T: Timestamp + Lattice + TotalOrder,
+    T: Timestamp + Lattice,
 {
     fn rule(&self, name: &str) -> Option<&Rule> {
         self.rules.get(name)
@@ -211,7 +211,7 @@ where
 
 impl<T, Token> Server<T, Token>
 where
-    T: Timestamp + Lattice + TotalOrder + Default + Rewind,
+    T: Timestamp + Lattice + Default + Rewind,
     Token: Hash + Eq + Copy,
 {
     /// Creates a new server state from a configuration.

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -8,7 +8,6 @@ use timely::dataflow::channels::pact::ParallelizationContract;
 use timely::dataflow::operators::generic::Operator;
 use timely::dataflow::operators::generic::OutputHandle;
 use timely::dataflow::{Scope, Stream};
-use timely::order::TotalOrder;
 use timely::progress::Timestamp;
 
 use differential_dataflow::lattice::Lattice;
@@ -24,7 +23,7 @@ pub use self::csv_file::CsvFile;
 /// An external system that wants to receive result diffs.
 pub trait Sinkable<T>
 where
-    T: Timestamp + Lattice + TotalOrder,
+    T: Timestamp + Lattice,
 {
     /// Creates a timely operator reading from the source andn
     /// producing inputs.

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -7,7 +7,6 @@ use std::time::{Duration, Instant};
 use timely::dataflow::operators::capture::event::link::EventLink;
 use timely::dataflow::{Scope, Stream};
 use timely::logging::TimelyEvent;
-use timely::order::TotalOrder;
 use timely::progress::Timestamp;
 
 use differential_dataflow::lattice::Lattice;

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -46,7 +46,7 @@ pub struct SourcingContext {
 pub trait Sourceable<S>
 where
     S: Scope,
-    S::Timestamp: Timestamp + Lattice + TotalOrder,
+    S::Timestamp: Timestamp + Lattice,
 {
     /// Conjures from thin air (or from wherever the source lives) one
     /// or more timely streams feeding directly into attributes.


### PR DESCRIPTION
Removes the need for totally ordered domain timestamps and thus allows us to run with bitemporal pairs.