### PR TITLE
Timeless Sources

### DIFF
--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -136,6 +136,7 @@ where
         // We do not want to probe timeless attributes.
         // Sources of timeless attributes either are not able to or do not
         // want to provide valid domain timestamps.
+        // Forcing to probe them would stall progress in the system.
         let source_pairs = if config.timeless {
             pairs.to_owned()
         } else {

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -28,7 +28,7 @@ pub struct Domain<T: Timestamp + Lattice> {
     /// Input handles to attributes in this domain.
     input_sessions: HashMap<String, UnorderedSession<T, (Value, Value), isize>>,
     /// The probe keeping track of source progress in this domain.
-    input_probe: ProbeHandle<T>,
+    domain_probe: ProbeHandle<T>,
     /// Configurations for attributes in this domain.
     pub attributes: HashMap<Aid, AttributeConfig>,
     /// Forward attribute indices eid -> v.
@@ -50,7 +50,7 @@ where
         Domain {
             now_at: start_at,
             input_sessions: HashMap::new(),
-            input_probe: ProbeHandle::new(),
+            domain_probe: ProbeHandle::new(),
             attributes: HashMap::new(),
             forward: HashMap::new(),
             reverse: HashMap::new(),
@@ -139,7 +139,7 @@ where
         let source_pairs = if config.timeless {
             pairs.to_owned()
         } else {
-            pairs.probe_with(&mut self.input_probe)
+            pairs.probe_with(&mut self.domain_probe)
         };
 
         self.create_attribute(name, config, &source_pairs)?;
@@ -260,7 +260,7 @@ where
     /// Advances all handles of the domain to its current frontier.
     pub fn advance_domain_to_source(&mut self) -> Result<(), Error> {
         let frontier = self
-            .input_probe
+            .domain_probe
             .with_frontier(|frontier| (*frontier).to_vec());
         self.advance_by(&frontier)
     }
@@ -337,7 +337,7 @@ where
     }
 
     /// Returns a handle to the domain's input probe.
-    pub fn input_probe(&self) -> &ProbeHandle<T> {
-        &self.input_probe
+    pub fn domain_probe(&self) -> &ProbeHandle<T> {
+        &self.domain_probe
     }
 }

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -132,9 +132,17 @@ where
     ) -> Result<(), Error> {
         // We need to install a probe on source-fed attributes in
         // order to determine their progress.
-        let probed_pairs = pairs.probe_with(&mut self.input_probe);
 
-        self.create_attribute(name, config, &probed_pairs)?;
+        // We do not want to probe timeless attributes.
+        // Sources of timeless attributes either are not able to or do not
+        // want to provide valid domain timestamps.
+        let source_pairs = if config.timeless {
+            pairs.to_owned()
+        } else {
+            pairs.probe_with(&mut self.input_probe)
+        };
+
+        self.create_attribute(name, config, &source_pairs)?;
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,6 +239,10 @@ pub struct AttributeConfig {
     /// How close indexed traces should follow the computation
     /// frontier.
     pub trace_slack: Option<Time>,
+    /// Does this attribute care about its respective time
+    /// dimension? Timeless attributes do not have an
+    /// influence on the overall progress in the system.
+    pub timeless: bool,
 }
 
 impl AttributeConfig {
@@ -253,6 +257,7 @@ impl AttributeConfig {
             // s.t. traces advance to t+1 when we're still accepting
             // inputs for t+1.
             trace_slack: Some(Time::TxId(1)),
+            timeless: false,
         }
     }
 
@@ -263,6 +268,7 @@ impl AttributeConfig {
         AttributeConfig {
             input_semantics,
             trace_slack: Some(Time::Real(Duration::from_secs(0))),
+            timeless: false,
         }
     }
 
@@ -272,6 +278,7 @@ impl AttributeConfig {
         AttributeConfig {
             input_semantics,
             trace_slack: None,
+            timeless: false,
         }
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -370,6 +370,7 @@ where
         let context = SourcingContext {
             t0: self.t0,
             scheduler: Rc::downgrade(&self.scheduler),
+            domain_probe: self.context.internal.input_probe().clone(),
             timely_events: self.timely_events.clone().unwrap(),
             differential_events: self.differential_events.clone().unwrap(),
         };

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -370,7 +370,7 @@ where
         let context = SourcingContext {
             t0: self.t0,
             scheduler: Rc::downgrade(&self.scheduler),
-            domain_probe: self.context.internal.input_probe().clone(),
+            domain_probe: self.context.internal.domain_probe().clone(),
             timely_events: self.timely_events.clone().unwrap(),
             differential_events: self.differential_events.clone().unwrap(),
         };

--- a/src/sources/csv_file.rs
+++ b/src/sources/csv_file.rs
@@ -38,7 +38,7 @@ impl<S: Scope<Timestamp = Duration>> Sourceable<S> for CsvFile {
     fn source(
         &self,
         scope: &mut S,
-        context: SourcingContext,
+        context: SourcingContext<S::Timestamp>,
     ) -> Vec<(
         Aid,
         AttributeConfig,

--- a/src/sources/differential_logging.rs
+++ b/src/sources/differential_logging.rs
@@ -28,7 +28,7 @@ impl<S: Scope<Timestamp = Duration>> Sourceable<S> for DifferentialLogging {
     fn source(
         &self,
         scope: &mut S,
-        context: SourcingContext,
+        context: SourcingContext<S::Timestamp>,
     ) -> Vec<(
         Aid,
         AttributeConfig,

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -5,7 +5,7 @@ use std::rc::{Rc, Weak};
 use std::time::{Duration, Instant};
 
 use timely::dataflow::operators::capture::event::link::EventLink;
-use timely::dataflow::{Scope, Stream};
+use timely::dataflow::{ProbeHandle, Scope, Stream};
 use timely::logging::TimelyEvent;
 use timely::progress::Timestamp;
 
@@ -28,10 +28,12 @@ pub use self::csv_file::CsvFile;
 // pub use self::json_file::JsonFile;
 
 /// A struct encapsulating any state required to create sources.
-pub struct SourcingContext {
+pub struct SourcingContext<T: Timestamp> {
     /// The logical start of the computation, used by sources to
     /// compute their relative progress.
     pub t0: Instant,
+    /// A handle to the timely probe of the domain this source is created in.
+    pub domain_probe: ProbeHandle<T>,
     /// A weak handle to a scheduler, used by sources to defer their
     /// next activation when polling.
     pub scheduler: Weak<RefCell<Scheduler>>,
@@ -52,7 +54,7 @@ where
     fn source(
         &self,
         scope: &mut S,
-        context: SourcingContext,
+        context: SourcingContext<S::Timestamp>,
     ) -> Vec<(
         Aid,
         AttributeConfig,
@@ -103,7 +105,7 @@ impl<S: Scope<Timestamp = u64>> Sourceable<S> for Source {
     fn source(
         &self,
         _scope: &mut S,
-        _context: SourcingContext,
+        _context: SourcingContext<S::Timestamp>,
     ) -> Vec<(
         Aid,
         AttributeConfig,

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -83,7 +83,7 @@ impl<S: Scope<Timestamp = Duration>> Sourceable<S> for Source {
     fn source(
         &self,
         scope: &mut S,
-        context: SourcingContext,
+        context: SourcingContext<S::Timestamp>,
     ) -> Vec<(
         Aid,
         AttributeConfig,

--- a/src/sources/timely_logging.rs
+++ b/src/sources/timely_logging.rs
@@ -27,7 +27,7 @@ impl<S: Scope<Timestamp = Duration>> Sourceable<S> for TimelyLogging {
     fn source(
         &self,
         scope: &mut S,
-        context: SourcingContext,
+        context: SourcingContext<S::Timestamp>,
     ) -> Vec<(
         Aid,
         AttributeConfig,


### PR DESCRIPTION
This adds the field `timeless` to the `AttributeConfig` which decides if a given attribute will be probed.
This also adds `domain_probe` to the `SourcingContext`, a `ProbeHandle` to the domain.

These two together allow sources that cannot or do not want to provide timestamps for their respective attributes to transact data at the current epoch.

This is especially necessary when running source driven. If a sources cannot provide timestamps, probing its values would block the overall system.