### PR TITLE
Memory friendly indexing

### DIFF
--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -120,6 +120,8 @@ where
                 InputSemantics::CardinalityMany => pairs.as_collection().distinct(),
             };
 
+            let tuples_reverse = tuples.map(|(e, v)| (v, e));
+
             // Propose traces are used in general, whereas the other
             // indices are only relevant to Hector.
             self.forward_propose.insert(
@@ -128,7 +130,7 @@ where
             );
             self.reverse_propose.insert(
                 name.to_string(),
-                tuples
+                tuples_reverse
                     .arrange_named(&format!("_Proposals({})", &name))
                     .trace,
             );
@@ -148,7 +150,7 @@ where
                     );
                     self.reverse_count.insert(
                         name.to_string(),
-                        tuples
+                        tuples_reverse
                             .map(|(k, _v)| (k, ()))
                             .arrange_named(&format!("_Counts({})", name))
                             .trace,
@@ -164,7 +166,7 @@ where
                 );
                 self.reverse_validate.insert(
                     name.to_string(),
-                    tuples
+                    tuples_reverse
                         .map(|t| (t, ()))
                         .arrange_named(&format!("_Validations({})", &name))
                         .trace,

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -417,14 +417,12 @@ where
 
         if self.probed_source_count() == 0 {
             frontier.less_than(self.epoch())
+        } else if frontier.is_empty() {
+            false
         } else {
-            if frontier.is_empty() {
-                false
-            } else {
-                self.domain_probe().with_frontier(|domain_frontier| {
-                    domain_frontier.iter().all(|t| frontier.less_than(t))
-                })
-            }
+            self.domain_probe().with_frontier(|domain_frontier| {
+                domain_frontier.iter().all(|t| frontier.less_than(t))
+            })
         }
     }
 }

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -9,6 +9,7 @@ use timely::progress::frontier::AntichainRef;
 use timely::progress::Timestamp;
 
 use differential_dataflow::lattice::Lattice;
+use differential_dataflow::operators::Threshold;
 use differential_dataflow::trace::TraceReader;
 use differential_dataflow::AsCollection;
 
@@ -97,43 +98,24 @@ where
                 name
             )))
         } else {
-            let (forward, reverse) = match config.input_semantics {
-                InputSemantics::Raw => {
-                    let tuples = pairs.as_collection();
-
-                    let forward = CollectionIndex::index(&name, &tuples);
-                    let reverse = CollectionIndex::index(&name, &tuples.map(|(e, v)| (v, e)));
-
-                    (forward, reverse)
-                }
-                InputSemantics::CardinalityOne => {
-                    let tuples = pairs.cardinality_single().as_collection();
-
-                    let forward = CollectionIndex::index(&name, &tuples);
-                    let reverse = CollectionIndex::index(&name, &tuples.map(|(e, v)| (v, e)));
-
-                    (forward, reverse)
-                }
-                InputSemantics::CardinalityMany => {
-                    // Ensure that redundant (e,v) pairs don't cause
-                    // misleading proposals during joining.
-                    let tuples = pairs.as_collection();
-
-                    let forward = CollectionIndex::index_distinct(&name, &tuples);
-                    let reverse =
-                        CollectionIndex::index_distinct(&name, &tuples.map(|(e, v)| (v, e)));
-
-                    (forward, reverse)
-                }
+            let tuples = match config.input_semantics {
+                InputSemantics::Raw => pairs.as_collection(),
+                InputSemantics::CardinalityOne => pairs.cardinality_single().as_collection(),
+                // Ensure that redundant (e,v) pairs don't cause
+                // misleading proposals during joining.
+                InputSemantics::CardinalityMany => pairs.as_collection().distinct(),
             };
-
-            self.forward.insert(name.to_string(), forward);
-            self.reverse.insert(name.to_string(), reverse);
 
             // This is crucial. If we forget to install the attribute
             // configuration, its traces will be ignored when
             // advancing the domain.
             self.attributes.insert(name.to_string(), config);
+
+            let forward = CollectionIndex::index(&name, &tuples);
+            let reverse = CollectionIndex::index(&name, &tuples.map(|(e, v)| (v, e)));
+
+            self.forward.insert(name.to_string(), forward);
+            self.reverse.insert(name.to_string(), reverse);
 
             info!("Created attribute {}", name);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,12 +315,27 @@ pub struct AttributeConfig {
     /// How close indexed traces should follow the computation
     /// frontier.
     pub trace_slack: Option<Time>,
+    // @TODO
+    // /// Will this attribute require reverse indices?
+    // pub enable_reverse: bool,
     /// Will this attribute be used in worst-case optimal queries?
     pub enable_wco: bool,
     /// Does this attribute care about its respective time
     /// dimension? Timeless attributes do not have an
     /// influence on the overall progress in the system.
     pub timeless: bool,
+}
+
+impl Default for AttributeConfig {
+    fn default() -> Self {
+        AttributeConfig {
+            input_semantics: InputSemantics::Raw,
+            trace_slack: None,
+            // enable_reverse: true,
+            enable_wco: false,
+            timeless: false,
+        }
+    }
 }
 
 impl AttributeConfig {
@@ -335,8 +350,7 @@ impl AttributeConfig {
             // s.t. traces advance to t+1 when we're still accepting
             // inputs for t+1.
             trace_slack: Some(Time::TxId(1)),
-            enable_wco: false,
-            timeless: false,
+            ..Default::default()
         }
     }
 
@@ -347,8 +361,7 @@ impl AttributeConfig {
         AttributeConfig {
             input_semantics,
             trace_slack: Some(Time::Real(Duration::from_secs(0))),
-            enable_wco: false,
-            timeless: false,
+            ..Default::default()
         }
     }
 
@@ -358,8 +371,7 @@ impl AttributeConfig {
         AttributeConfig {
             input_semantics,
             trace_slack: None,
-            enable_wco: false,
-            timeless: false,
+            ..Default::default()
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,6 +314,8 @@ pub struct AttributeConfig {
     /// How close indexed traces should follow the computation
     /// frontier.
     pub trace_slack: Option<Time>,
+    /// Will this attribute be used in worst-case optimal queries?
+    pub enable_wco: bool,
     /// Does this attribute care about its respective time
     /// dimension? Timeless attributes do not have an
     /// influence on the overall progress in the system.
@@ -332,6 +334,7 @@ impl AttributeConfig {
             // s.t. traces advance to t+1 when we're still accepting
             // inputs for t+1.
             trace_slack: Some(Time::TxId(1)),
+            enable_wco: false,
             timeless: false,
         }
     }
@@ -343,6 +346,7 @@ impl AttributeConfig {
         AttributeConfig {
             input_semantics,
             trace_slack: Some(Time::Real(Duration::from_secs(0))),
+            enable_wco: false,
             timeless: false,
         }
     }
@@ -353,6 +357,7 @@ impl AttributeConfig {
         AttributeConfig {
             input_semantics,
             trace_slack: None,
+            enable_wco: false,
             timeless: false,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,6 +244,7 @@ pub struct ShutdownHandle {
 
 impl Drop for ShutdownHandle {
     fn drop(&mut self) {
+        trace!("Dropping ShutdownHandle");
         for mut button in self.shutdown_buttons.drain(..) {
             button.press();
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,13 +32,13 @@ use timely::order::Product;
 use timely::progress::timestamp::Refines;
 use timely::progress::Timestamp;
 
-use differential_dataflow::difference::Monoid;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::{Arrange, Arranged, ShutdownButton, TraceAgent};
 use differential_dataflow::operators::iterate::Variable;
-use differential_dataflow::operators::reduce::ReduceCore;
 #[cfg(not(feature = "set-semantics"))]
 use differential_dataflow::operators::Consolidate;
+#[cfg(feature = "set-semantics")]
+use differential_dataflow::operators::Threshold;
 use differential_dataflow::trace::implementations::ord::{OrdKeySpine, OrdValSpine};
 use differential_dataflow::trace::wrappers::enter::TraceEnter;
 use differential_dataflow::trace::wrappers::enter_at::TraceEnter as TraceEnterAt;
@@ -426,72 +426,6 @@ where
             .map(|t| (t, ()))
             .arrange_named(&format!("Validations({})", &name))
             .trace;
-
-        CollectionIndex {
-            name: name.to_string(),
-            count_trace,
-            propose_trace,
-            validate_trace,
-        }
-    }
-
-    /// Creates a named CollectionIndex from a (K, V) collection,
-    /// enforces distinct pairs.
-    pub fn index_distinct<G: Scope<Timestamp = T>>(
-        name: &str,
-        collection: &Collection<G, (K, V), isize>,
-    ) -> Self {
-        let count_trace = {
-            let arrange: Arranged<G, TraceKeyHandle<K, T, isize>> = collection
-                .map(|(k, _v)| (k, ()))
-                .arrange_named(&format!("DistinctCounts({})", name));
-
-            arrange
-                .reduce_abelian::<_, OrdKeySpine<K, T, isize>>(
-                    move |k: &K, s: &[(&(), isize)], t: &mut Vec<((), isize)>| {
-                        if s[0].1.is_zero() {
-                            t.push(((), 0))
-                        } else {
-                            t.push(((), 1))
-                        }
-                    },
-                )
-                .trace
-        };
-
-        let propose_trace = {
-            let arrange: Arranged<G, TraceValHandle<K, V, T, isize>> =
-                collection.arrange_named(&format!("DistinctProposals({})", &name));
-
-            arrange
-                .reduce_abelian::<_, OrdValSpine<K, V, T, isize>>(move |k, s: &[(&V, isize)], t| {
-                    let mut values = s.iter().map(|(v, _diff)| *v).cloned().collect::<Vec<V>>();
-
-                    // Values arrive already sorted, so we can dedup.
-                    values.dedup();
-
-                    for v in values.drain(..) {
-                        t.push((v, 1));
-                    }
-                })
-                .trace
-        };
-
-        let validate_trace = {
-            let arrange: Arranged<G, TraceKeyHandle<(K, V), T, isize>> = collection
-                .map(|t| (t, ()))
-                .arrange_named(&format!("DistinctValidations({})", &name));
-
-            arrange
-                .reduce_abelian::<_, OrdKeySpine<(K, V), T, isize>>(move |k, s, t| {
-                    if s[0].1.is_zero() {
-                        t.push(((), 0))
-                    } else {
-                        t.push(((), 1))
-                    }
-                })
-                .trace
-        };
 
         CollectionIndex {
             name: name.to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,27 +22,23 @@ pub mod sources;
 pub mod timestamp;
 
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::hash::Hash;
 use std::time::Duration;
 
 use timely::dataflow::operators::CapabilitySet;
-use timely::dataflow::scopes::child::{Child, Iterative};
+use timely::dataflow::scopes::child::Iterative;
 use timely::dataflow::*;
 use timely::order::Product;
-use timely::progress::timestamp::Refines;
 use timely::progress::Timestamp;
 
 use differential_dataflow::lattice::Lattice;
-use differential_dataflow::operators::arrange::{Arrange, Arranged, ShutdownButton, TraceAgent};
+use differential_dataflow::operators::arrange::{ShutdownButton, TraceAgent};
 use differential_dataflow::operators::iterate::Variable;
 #[cfg(not(feature = "set-semantics"))]
 use differential_dataflow::operators::Consolidate;
 #[cfg(feature = "set-semantics")]
 use differential_dataflow::operators::Threshold;
 use differential_dataflow::trace::implementations::ord::{OrdKeySpine, OrdValSpine};
-use differential_dataflow::trace::wrappers::enter::TraceEnter;
-use differential_dataflow::trace::wrappers::enter_at::TraceEnter as TraceEnterAt;
-use differential_dataflow::trace::{BatchReader, Cursor, TraceReader};
+use differential_dataflow::trace::TraceReader;
 use differential_dataflow::{Collection, ExchangeData};
 
 #[cfg(feature = "uuid")]
@@ -370,263 +366,6 @@ pub struct RelationConfig {
     pub trace_slack: Option<Time>,
 }
 
-/// Various indices over a collection of (K, V) pairs, required to
-/// participate in delta-join pipelines.
-pub struct CollectionIndex<K, V, T>
-where
-    K: ExchangeData,
-    V: ExchangeData,
-    T: Lattice + ExchangeData,
-{
-    /// A name uniquely identifying this index.
-    pub name: String,
-    /// A trace of type (K, ()), used to count extensions for each prefix.
-    pub count_trace: TraceKeyHandle<K, T, isize>,
-    /// A trace of type (K, V), used to propose extensions for each prefix.
-    pub propose_trace: TraceValHandle<K, V, T, isize>,
-    /// A trace of type ((K, V), ()), used to validate proposed extensions.
-    pub validate_trace: TraceKeyHandle<(K, V), T, isize>,
-}
-
-impl<K, V, T> Clone for CollectionIndex<K, V, T>
-where
-    K: ExchangeData + Hash,
-    V: ExchangeData + Hash,
-    T: Lattice + ExchangeData + Timestamp,
-{
-    fn clone(&self) -> Self {
-        CollectionIndex {
-            name: self.name.clone(),
-            count_trace: self.count_trace.clone(),
-            propose_trace: self.propose_trace.clone(),
-            validate_trace: self.validate_trace.clone(),
-        }
-    }
-}
-
-impl<K, V, T> CollectionIndex<K, V, T>
-where
-    K: ExchangeData + Hash,
-    V: ExchangeData + Hash,
-    T: Lattice + ExchangeData + Timestamp,
-{
-    /// Creates a named CollectionIndex from a (K, V) collection.
-    pub fn index<G: Scope<Timestamp = T>>(
-        name: &str,
-        collection: &Collection<G, (K, V), isize>,
-    ) -> Self {
-        let count_trace = collection
-            .map(|(k, _v)| (k, ()))
-            .arrange_named(&format!("Counts({})", name))
-            .trace;
-        let propose_trace = collection
-            .arrange_named(&format!("Proposals({})", &name))
-            .trace;
-        let validate_trace = collection
-            .map(|t| (t, ()))
-            .arrange_named(&format!("Validations({})", &name))
-            .trace;
-
-        CollectionIndex {
-            name: name.to_string(),
-            count_trace,
-            propose_trace,
-            validate_trace,
-        }
-    }
-
-    /// Returns a LiveIndex that lives in the specified scope.
-    pub fn import<G: Scope<Timestamp = T>>(
-        &mut self,
-        scope: &G,
-    ) -> (
-        LiveIndex<
-            G,
-            K,
-            V,
-            TraceKeyHandle<K, T, isize>,
-            TraceValHandle<K, V, T, isize>,
-            TraceKeyHandle<(K, V), T, isize>,
-        >,
-        ShutdownHandle,
-    ) {
-        let (count, shutdown_count) = self
-            .count_trace
-            .import_core(scope, &format!("Counts({})", self.name));
-        let (propose, shutdown_propose) = self
-            .propose_trace
-            .import_core(scope, &format!("Proposals({})", self.name));
-        let (validate, shutdown_validate) = self
-            .validate_trace
-            .import_core(scope, &format!("Validations({})", self.name));
-
-        let index = LiveIndex {
-            count,
-            propose,
-            validate,
-        };
-
-        let mut shutdown_handle = ShutdownHandle::empty();
-        shutdown_handle.add_button(shutdown_count);
-        shutdown_handle.add_button(shutdown_propose);
-        shutdown_handle.add_button(shutdown_validate);
-
-        (index, shutdown_handle)
-    }
-
-    /// Allows Differential to logically compact trace batches on this
-    /// attribute, up to frontier.
-    pub fn advance_by(&mut self, frontier: &[T]) {
-        self.count_trace.advance_by(frontier);
-        self.propose_trace.advance_by(frontier);
-        self.validate_trace.advance_by(frontier);
-    }
-
-    /// Allows Differential to physically merge trace batches on this
-    /// attribute, up to frontier.
-    pub fn distinguish_since(&mut self, frontier: &[T]) {
-        self.count_trace.distinguish_since(frontier);
-        self.propose_trace.distinguish_since(frontier);
-        self.validate_trace.distinguish_since(frontier);
-    }
-}
-
-/// CollectionIndex that was imported into a scope.
-pub struct LiveIndex<G, K, V, TrCount, TrPropose, TrValidate>
-where
-    G: Scope,
-    G::Timestamp: Lattice + ExchangeData,
-    K: ExchangeData,
-    V: ExchangeData,
-    TrCount: TraceReader<Key = K, Val = (), Time = G::Timestamp, R = isize> + Clone,
-    TrCount::Batch: BatchReader<TrCount::Key, TrCount::Val, G::Timestamp, TrCount::R> + 'static,
-    TrCount::Cursor: Cursor<TrCount::Key, TrCount::Val, G::Timestamp, TrCount::R> + 'static,
-    TrPropose: TraceReader<Key = K, Val = V, Time = G::Timestamp, R = isize> + Clone,
-    TrPropose::Batch:
-        BatchReader<TrPropose::Key, TrPropose::Val, G::Timestamp, TrPropose::R> + 'static,
-    TrPropose::Cursor: Cursor<TrPropose::Key, TrPropose::Val, G::Timestamp, TrPropose::R> + 'static,
-    TrValidate: TraceReader<Key = (K, V), Val = (), Time = G::Timestamp, R = isize> + Clone,
-    TrValidate::Batch:
-        BatchReader<TrValidate::Key, TrValidate::Val, G::Timestamp, TrValidate::R> + 'static,
-    TrValidate::Cursor:
-        Cursor<TrValidate::Key, TrValidate::Val, G::Timestamp, TrValidate::R> + 'static,
-{
-    count: Arranged<G, TrCount>,
-    propose: Arranged<G, TrPropose>,
-    validate: Arranged<G, TrValidate>,
-}
-
-impl<G, K, V, TrCount, TrPropose, TrValidate> Clone
-    for LiveIndex<G, K, V, TrCount, TrPropose, TrValidate>
-where
-    G: Scope,
-    G::Timestamp: Lattice + ExchangeData,
-    K: ExchangeData,
-    V: ExchangeData,
-    TrCount: TraceReader<Key = K, Val = (), Time = G::Timestamp, R = isize> + Clone,
-    TrCount::Batch: BatchReader<TrCount::Key, TrCount::Val, G::Timestamp, TrCount::R> + 'static,
-    TrCount::Cursor: Cursor<TrCount::Key, TrCount::Val, G::Timestamp, TrCount::R> + 'static,
-    TrPropose: TraceReader<Key = K, Val = V, Time = G::Timestamp, R = isize> + Clone,
-    TrPropose::Batch:
-        BatchReader<TrPropose::Key, TrPropose::Val, G::Timestamp, TrPropose::R> + 'static,
-    TrPropose::Cursor: Cursor<TrPropose::Key, TrPropose::Val, G::Timestamp, TrPropose::R> + 'static,
-    TrValidate: TraceReader<Key = (K, V), Val = (), Time = G::Timestamp, R = isize> + Clone,
-    TrValidate::Batch:
-        BatchReader<TrValidate::Key, TrValidate::Val, G::Timestamp, TrValidate::R> + 'static,
-    TrValidate::Cursor:
-        Cursor<TrValidate::Key, TrValidate::Val, G::Timestamp, TrValidate::R> + 'static,
-{
-    fn clone(&self) -> Self {
-        LiveIndex {
-            count: self.count.clone(),
-            propose: self.propose.clone(),
-            validate: self.validate.clone(),
-        }
-    }
-}
-
-impl<G, K, V, TrCount, TrPropose, TrValidate> LiveIndex<G, K, V, TrCount, TrPropose, TrValidate>
-where
-    G: Scope,
-    G::Timestamp: Lattice + ExchangeData,
-    K: ExchangeData,
-    V: ExchangeData,
-    TrCount: TraceReader<Key = K, Val = (), Time = G::Timestamp, R = isize> + Clone,
-    TrCount::Batch: BatchReader<TrCount::Key, TrCount::Val, G::Timestamp, TrCount::R> + 'static,
-    TrCount::Cursor: Cursor<TrCount::Key, TrCount::Val, G::Timestamp, TrCount::R> + 'static,
-    TrPropose: TraceReader<Key = K, Val = V, Time = G::Timestamp, R = isize> + Clone,
-    TrPropose::Batch:
-        BatchReader<TrPropose::Key, TrPropose::Val, G::Timestamp, TrPropose::R> + 'static,
-    TrPropose::Cursor: Cursor<TrPropose::Key, TrPropose::Val, G::Timestamp, TrPropose::R> + 'static,
-    TrValidate: TraceReader<Key = (K, V), Val = (), Time = G::Timestamp, R = isize> + Clone,
-    TrValidate::Batch:
-        BatchReader<TrValidate::Key, TrValidate::Val, G::Timestamp, TrValidate::R> + 'static,
-    TrValidate::Cursor:
-        Cursor<TrValidate::Key, TrValidate::Val, G::Timestamp, TrValidate::R> + 'static,
-{
-    /// Brings the index's traces into the specified scope.
-    pub fn enter<'a, TInner>(
-        &self,
-        child: &Child<'a, G, TInner>,
-    ) -> LiveIndex<
-        Child<'a, G, TInner>,
-        K,
-        V,
-        TraceEnter<TrCount, TInner>,
-        TraceEnter<TrPropose, TInner>,
-        TraceEnter<TrValidate, TInner>,
-    >
-    where
-        TrCount::Batch: Clone,
-        TrPropose::Batch: Clone,
-        TrValidate::Batch: Clone,
-        K: 'static,
-        V: 'static,
-        G::Timestamp: Clone + Default + 'static,
-        TInner: Refines<G::Timestamp> + Lattice + Timestamp + Clone + Default + 'static,
-    {
-        LiveIndex {
-            count: self.count.enter(child),
-            propose: self.propose.enter(child),
-            validate: self.validate.enter(child),
-        }
-    }
-
-    /// Brings the index's traces into the specified scope.
-    pub fn enter_at<'a, TInner, FCount, FPropose, FValidate>(
-        &self,
-        child: &Child<'a, G, TInner>,
-        fcount: FCount,
-        fpropose: FPropose,
-        fvalidate: FValidate,
-    ) -> LiveIndex<
-        Child<'a, G, TInner>,
-        K,
-        V,
-        TraceEnterAt<TrCount, TInner, FCount>,
-        TraceEnterAt<TrPropose, TInner, FPropose>,
-        TraceEnterAt<TrValidate, TInner, FValidate>,
-    >
-    where
-        TrCount::Batch: Clone,
-        TrPropose::Batch: Clone,
-        TrValidate::Batch: Clone,
-        K: 'static,
-        V: 'static,
-        G::Timestamp: Clone + Default + 'static,
-        TInner: Refines<G::Timestamp> + Lattice + Timestamp + Clone + Default + 'static,
-        FCount: Fn(&K, &(), &G::Timestamp) -> TInner + 'static,
-        FPropose: Fn(&K, &V, &G::Timestamp) -> TInner + 'static,
-        FValidate: Fn(&(K, V), &(), &G::Timestamp) -> TInner + 'static,
-    {
-        LiveIndex {
-            count: self.count.enter_at(child, fcount),
-            propose: self.propose.enter_at(child, fpropose),
-            validate: self.validate.enter_at(child, fvalidate),
-        }
-    }
-}
-
 /// A variable used in a query.
 type Var = u32;
 
@@ -845,13 +584,12 @@ where
         Collection<Iterative<'a, G, u64>, Vec<Value>, isize>,
         ShutdownHandle,
     ) {
-        match context.forward_index(&self.source_attribute) {
+        match context.forward_propose(&self.source_attribute) {
             None => panic!("attribute {:?} does not exist", self.source_attribute),
-            Some(index) => {
-                let frontier = index.propose_trace.advance_frontier().to_vec();
-                let (propose, shutdown_propose) = index
-                    .propose_trace
-                    .import_core(&nested.parent, &self.source_attribute);
+            Some(propose_trace) => {
+                let frontier = propose_trace.advance_frontier().to_vec();
+                let (propose, shutdown_propose) =
+                    propose_trace.import_core(&nested.parent, &self.source_attribute);
 
                 let tuples = propose.enter_at(nested, move |_, _, time| {
                     let mut forwarded = time.clone();
@@ -886,13 +624,12 @@ where
         Collection<Iterative<'a, G, u64>, (Vec<Value>, Vec<Value>), isize>,
         ShutdownHandle,
     ) {
-        match context.forward_index(&self.source_attribute) {
+        match context.forward_propose(&self.source_attribute) {
             None => panic!("attribute {:?} does not exist", self.source_attribute),
-            Some(index) => {
-                let frontier = index.propose_trace.advance_frontier().to_vec();
-                let (propose, shutdown_propose) = index
-                    .propose_trace
-                    .import_core(&nested.parent, &self.source_attribute);
+            Some(propose_trace) => {
+                let frontier = propose_trace.advance_frontier().to_vec();
+                let (propose, shutdown_propose) =
+                    propose_trace.import_core(&nested.parent, &self.source_attribute);
 
                 let tuples = propose.enter_at(nested, move |_, _, time| {
                     let mut forwarded = time.clone();

--- a/src/plan/join.rs
+++ b/src/plan/join.rs
@@ -50,16 +50,14 @@ where
         let (mut index, shutdown_button) = if target == left.variables.0 {
             variables.push(left.variables.1);
             context
-                .forward_index(&left.source_attribute)
+                .forward_propose(&left.source_attribute)
                 .unwrap()
-                .propose_trace
                 .import_core(&nested.parent, &left.source_attribute)
         } else if target == left.variables.1 {
             variables.push(left.variables.0);
             context
-                .reverse_index(&left.source_attribute)
+                .reverse_propose(&left.source_attribute)
                 .unwrap()
-                .propose_trace
                 .import_core(&nested.parent, &left.source_attribute)
         } else {
             panic!("Unbound target variable in Attribute<->Attribute join.");
@@ -79,16 +77,14 @@ where
         let (mut index, shutdown_button) = if target == right.variables.0 {
             variables.push(right.variables.1);
             context
-                .forward_index(&right.source_attribute)
+                .forward_propose(&right.source_attribute)
                 .unwrap()
-                .propose_trace
                 .import_core(&nested.parent, &right.source_attribute)
         } else if target == right.variables.1 {
             variables.push(right.variables.0);
             context
-                .reverse_index(&right.source_attribute)
+                .reverse_propose(&right.source_attribute)
                 .unwrap()
-                .propose_trace
                 .import_core(&nested.parent, &right.source_attribute)
         } else {
             panic!("Unbound target variable in Attribute<->Attribute join.");
@@ -198,13 +194,12 @@ where
 {
     // @TODO specialized implementation
 
-    let (tuples, shutdown_validate) = match context.forward_index(&right.source_attribute) {
+    let (tuples, shutdown_validate) = match context.forward_validate(&right.source_attribute) {
         None => panic!("attribute {:?} does not exist", &right.source_attribute),
-        Some(index) => {
-            let frontier: Vec<T> = index.validate_trace.advance_frontier().to_vec();
-            let (validate, shutdown_validate) = index
-                .validate_trace
-                .import_core(&nested.parent, &right.source_attribute);
+        Some(validate_trace) => {
+            let frontier: Vec<T> = validate_trace.advance_frontier().to_vec();
+            let (validate, shutdown_validate) =
+                validate_trace.import_core(&nested.parent, &right.source_attribute);
 
             let tuples = validate
                 .enter_at(nested, move |_, _, time| {
@@ -235,9 +230,8 @@ where
 //                 assert!(*var == self.variables.1);
 
 //                 let (index, shutdown_button) = context
-//                     .forward_index(&self.source_attribute)
+//                     .forward_validate(&self.source_attribute)
 //                     .unwrap()
-//                     .validate_trace
 //                     .import_core(&scope.parent, &self.source_attribute);
 
 //                 let frontier = index.trace.advance_frontier().to_vec();
@@ -254,9 +248,8 @@ where
 //                 assert!(*var == self.variables.0);
 
 //                 let (index, shutdown_button) = context
-//                     .reverse_index(&self.source_attribute)
+//                     .reverse_validate(&self.source_attribute)
 //                     .unwrap()
-//                     .validate_trace
 //                     .import_core(&scope.parent, &self.source_attribute);
 
 //                 let frontier = index.trace.advance_frontier().to_vec();

--- a/src/plan/pull.rs
+++ b/src/plan/pull.rs
@@ -143,12 +143,12 @@ impl<P: Implementable> Implementable for PullLevel<P> {
 
             let mut shutdown_handle = shutdown_handle;
             let streams = self.pull_attributes.iter().map(|a| {
-                let e_v = match context.forward_index(a) {
+                let e_v = match context.forward_propose(a) {
                     None => panic!("attribute {:?} does not exist", a),
-                    Some(index) => {
-                        let frontier: Vec<T> = index.propose_trace.advance_frontier().to_vec();
+                    Some(propose_trace) => {
+                        let frontier: Vec<T> = propose_trace.advance_frontier().to_vec();
                         let (arranged, shutdown_propose) =
-                            index.propose_trace.import_core(&nested.parent, a);
+                            propose_trace.import_core(&nested.parent, a);
 
                         let e_v = arranged.enter_at(nested, move |_, _, time| {
                             let mut forwarded = time.clone();

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -23,10 +23,9 @@ use crate::plan::{ImplContext, Implementable};
 use crate::sinks::Sink;
 use crate::sources::{Source, Sourceable, SourcingContext};
 use crate::Rule;
-use crate::{
-    implement, implement_neu, AttributeConfig, CollectionIndex, RelationHandle, ShutdownHandle,
-};
+use crate::{implement, implement_neu, AttributeConfig, RelationHandle, ShutdownHandle};
 use crate::{Aid, Error, Rewind, Time, TxData, Value};
+use crate::{TraceKeyHandle, TraceValHandle};
 
 pub mod scheduler;
 use self::scheduler::Scheduler;
@@ -202,15 +201,43 @@ where
     }
 
     fn has_attribute(&self, name: &str) -> bool {
-        self.internal.forward.contains_key(name)
+        self.internal.attributes.contains_key(name)
     }
 
-    fn forward_index(&mut self, name: &str) -> Option<&mut CollectionIndex<Value, Value, T>> {
-        self.internal.forward.get_mut(name)
+    fn forward_count(&mut self, name: &str) -> Option<&mut TraceKeyHandle<Value, T, isize>> {
+        self.internal.forward_count.get_mut(name)
     }
 
-    fn reverse_index(&mut self, name: &str) -> Option<&mut CollectionIndex<Value, Value, T>> {
-        self.internal.reverse.get_mut(name)
+    fn forward_propose(
+        &mut self,
+        name: &str,
+    ) -> Option<&mut TraceValHandle<Value, Value, T, isize>> {
+        self.internal.forward_propose.get_mut(name)
+    }
+
+    fn forward_validate(
+        &mut self,
+        name: &str,
+    ) -> Option<&mut TraceKeyHandle<(Value, Value), T, isize>> {
+        self.internal.forward_validate.get_mut(name)
+    }
+
+    fn reverse_count(&mut self, name: &str) -> Option<&mut TraceKeyHandle<Value, T, isize>> {
+        self.internal.reverse_count.get_mut(name)
+    }
+
+    fn reverse_propose(
+        &mut self,
+        name: &str,
+    ) -> Option<&mut TraceValHandle<Value, Value, T, isize>> {
+        self.internal.reverse_propose.get_mut(name)
+    }
+
+    fn reverse_validate(
+        &mut self,
+        name: &str,
+    ) -> Option<&mut TraceKeyHandle<(Value, Value), T, isize>> {
+        self.internal.reverse_validate.get_mut(name)
     }
 
     fn is_underconstrained(&self, _name: &str) -> bool {

--- a/src/sources/csv_file.rs
+++ b/src/sources/csv_file.rs
@@ -108,7 +108,7 @@ impl<S: Scope<Timestamp = Duration>> Sourceable<S> for CsvFile {
                     capabilities.drain(..);
                 } else {
                     let mut fuel = total_fuel;
-                    
+
                     let mut handles = Vec::with_capacity(schema.len());
                     for wrapper in wrappers.iter_mut() {
                         handles.push(wrapper.activate());

--- a/src/sources/csv_file.rs
+++ b/src/sources/csv_file.rs
@@ -108,7 +108,7 @@ impl<S: Scope<Timestamp = Duration>> Sourceable<S> for CsvFile {
                     capabilities.drain(..);
                 } else {
                     let mut fuel = total_fuel;
-
+                    
                     let mut handles = Vec::with_capacity(schema.len());
                     for wrapper in wrappers.iter_mut() {
                         handles.push(wrapper.activate());

--- a/tests/domain_test.rs
+++ b/tests/domain_test.rs
@@ -95,37 +95,33 @@ fn test_advance_only_source() {
         assert!(!domain.dominates(AntichainRef::new(&[0])));
         assert_eq!(
             domain
-                .forward
+                .forward_propose
                 .get_mut("tx_test")
                 .unwrap()
-                .propose_trace
                 .advance_frontier(),
             &[0]
         );
         assert_eq!(
             domain
-                .forward
+                .forward_propose
                 .get_mut("tx_test")
                 .unwrap()
-                .propose_trace
                 .distinguish_frontier(),
             &[0]
         );
         assert_eq!(
             domain
-                .forward
+                .forward_propose
                 .get_mut("source_test")
                 .unwrap()
-                .propose_trace
                 .advance_frontier(),
             &[0]
         );
         assert_eq!(
             domain
-                .forward
+                .forward_propose
                 .get_mut("source_test")
                 .unwrap()
-                .propose_trace
                 .distinguish_frontier(),
             &[0]
         );
@@ -140,37 +136,33 @@ fn test_advance_only_source() {
         assert!(!domain.dominates(AntichainRef::new(&[1])));
         assert_eq!(
             domain
-                .forward
+                .forward_propose
                 .get_mut("tx_test")
                 .unwrap()
-                .propose_trace
                 .advance_frontier(),
             &[0]
         );
         assert_eq!(
             domain
-                .forward
+                .forward_propose
                 .get_mut("tx_test")
                 .unwrap()
-                .propose_trace
                 .distinguish_frontier(),
             &[0]
         );
         assert_eq!(
             domain
-                .forward
+                .forward_propose
                 .get_mut("source_test")
                 .unwrap()
-                .propose_trace
                 .advance_frontier(),
             &[0]
         );
         assert_eq!(
             domain
-                .forward
+                .forward_propose
                 .get_mut("source_test")
                 .unwrap()
-                .propose_trace
                 .distinguish_frontier(),
             &[0]
         );
@@ -185,37 +177,33 @@ fn test_advance_only_source() {
         assert!(!domain.dominates(AntichainRef::new(&[2])));
         assert_eq!(
             domain
-                .forward
+                .forward_propose
                 .get_mut("tx_test")
                 .unwrap()
-                .propose_trace
                 .advance_frontier(),
             &[1]
         );
         assert_eq!(
             domain
-                .forward
+                .forward_propose
                 .get_mut("tx_test")
                 .unwrap()
-                .propose_trace
                 .distinguish_frontier(),
             &[1]
         );
         assert_eq!(
             domain
-                .forward
+                .forward_propose
                 .get_mut("source_test")
                 .unwrap()
-                .propose_trace
                 .advance_frontier(),
             &[1]
         );
         assert_eq!(
             domain
-                .forward
+                .forward_propose
                 .get_mut("source_test")
                 .unwrap()
-                .propose_trace
                 .distinguish_frontier(),
             &[1]
         );

--- a/tests/hector_test.rs
+++ b/tests/hector_test.rs
@@ -373,14 +373,13 @@ fn run_hector_cases() {
 
             worker.dataflow::<u64, _, _>(|scope| {
                 for dep in deps.attributes.iter() {
+                    let mut config = AttributeConfig::tx_time(InputSemantics::Raw);
+                    config.enable_wco = true;
+
                     server
                         .context
                         .internal
-                        .create_transactable_attribute(
-                            dep,
-                            AttributeConfig::tx_time(InputSemantics::Raw),
-                            scope,
-                        )
+                        .create_transactable_attribute(dep, config, scope)
                         .unwrap();
                 }
 

--- a/tests/or_test.rs
+++ b/tests/or_test.rs
@@ -51,14 +51,13 @@ fn run_cases(mut cases: Vec<Case>) {
 
             worker.dataflow::<u64, _, _>(|scope| {
                 for dep in deps.iter() {
+                    let mut config = AttributeConfig::tx_time(InputSemantics::Raw);
+                    config.enable_wco = true;
+
                     server
                         .context
                         .internal
-                        .create_transactable_attribute(
-                            dep,
-                            AttributeConfig::tx_time(InputSemantics::Raw),
-                            scope,
-                        )
+                        .create_transactable_attribute(dep, config, scope)
                         .unwrap();
                 }
 

--- a/tests/query_test.rs
+++ b/tests/query_test.rs
@@ -50,14 +50,13 @@ fn run_cases(mut cases: Vec<Case>) {
 
             worker.dataflow::<u64, _, _>(|scope| {
                 for dep in deps.iter() {
+                    let mut config = AttributeConfig::tx_time(InputSemantics::CardinalityMany);
+                    config.enable_wco = true;
+
                     server
                         .context
                         .internal
-                        .create_transactable_attribute(
-                            dep,
-                            AttributeConfig::tx_time(InputSemantics::CardinalityMany),
-                            scope,
-                        )
+                        .create_transactable_attribute(dep, config, scope)
                         .unwrap();
                 }
 


### PR DESCRIPTION
This PR makes attribute indexing more flexible. We used to index every single attribute for full WCO compatibility. This now has to be enabled explicitly via the attribute configuration. We also make it possible to disable reverse indexing.