### PR TITLE
Extend cardinality_single to hash uuids

### DIFF
--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -58,12 +58,21 @@ where
                         }
                     }
                 },
-                |e| {
-                    if let Value::Eid(eid) = e {
-                        *eid as u64
-                    } else {
-                        panic!("Expected an eid.");
+                |e| match e {
+                    Value::Eid(eid) => *eid as u64,
+
+                    #[cfg(feature = "uuid")]
+                    Value::Uuid(uuid) => {
+                        use std::collections::hash_map::DefaultHasher;
+                        use std::hash::Hash;
+                        use std::hash::Hasher;
+
+                        let mut hasher = DefaultHasher::new();
+                        uuid.hash(&mut hasher);
+
+                        hasher.finish()
                     }
+                    _ => panic!("Not an eid or uuid: {:?}.", e),
                 },
             )
             .as_collection()

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -60,18 +60,11 @@ where
                 },
                 |e| match e {
                     Value::Eid(eid) => *eid as u64,
-
                     #[cfg(feature = "uuid")]
                     Value::Uuid(uuid) => {
-                        use std::collections::hash_map::DefaultHasher;
-                        use std::hash::Hash;
-                        use std::hash::Hasher;
-
-                        let mut hasher = DefaultHasher::new();
-                        uuid.hash(&mut hasher);
-
-                        hasher.finish()
-                    }
+                        use differential_dataflow::hashable::Hashable;
+                        uuid.hashed()
+                    },
                     _ => panic!("Not an eid or uuid: {:?}.", e),
                 },
             )


### PR DESCRIPTION
In case we are using `uuids` as our entities, we also want to hash them correctly in the cardinality_single operator.