### PR TITLE
Server fixes

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 
 [dependencies]
 jemallocator = "0.1.8"
-timely = { version = "0.10.0", features = ["bincode"] }
-differential-dataflow = { version = "0.10.0" }
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", features = ["bincode"] }
+differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow" }
 declarative-dataflow = { path = "../", features = ["serde_json", "uuid"] }
 serde = "1"
 serde_derive = "1"

--- a/src/scheduling/mod.rs
+++ b/src/scheduling/mod.rs
@@ -8,8 +8,8 @@ pub mod frontier_scheduler;
 pub use frontier_scheduler::FrontierScheduler;
 
 pub mod realtime_scheduler;
-pub use realtime_scheduler::RealtimeScheduler;
 pub use realtime_scheduler::Event as SchedulingEvent;
+pub use realtime_scheduler::RealtimeScheduler;
 
 /// Common scheduler behaviour.
 pub trait AsScheduler {

--- a/src/scheduling/mod.rs
+++ b/src/scheduling/mod.rs
@@ -8,7 +8,8 @@ pub mod frontier_scheduler;
 pub use frontier_scheduler::FrontierScheduler;
 
 pub mod realtime_scheduler;
-pub use realtime_scheduler::{Event, RealtimeScheduler};
+pub use realtime_scheduler::RealtimeScheduler;
+pub use realtime_scheduler::Event as SchedulingEvent;
 
 /// Common scheduler behaviour.
 pub trait AsScheduler {

--- a/src/sources/csv_file.rs
+++ b/src/sources/csv_file.rs
@@ -193,6 +193,7 @@ impl<S: Scope<Timestamp = Duration>> Sourceable<S> for CsvFile {
                                 .upgrade()
                                 .unwrap()
                                 .borrow_mut()
+                                .realtime
                                 .schedule_after(interval, Rc::downgrade(&activator))
                         }
                     }

--- a/tests/scheduling_test.rs
+++ b/tests/scheduling_test.rs
@@ -1,4 +1,4 @@
-use declarative_dataflow::scheduling::{AsScheduler, Event, RealtimeScheduler};
+use declarative_dataflow::scheduling::{AsScheduler, RealtimeScheduler, SchedulingEvent};
 use std::time::Duration;
 
 #[test]
@@ -8,17 +8,20 @@ fn test_schedule_now() {
     assert!(!scheduler.has_pending());
     assert!(scheduler.until_next().is_none());
 
-    scheduler.event_after(Duration::from_secs(0), Event::Tick);
+    scheduler.event_after(Duration::from_secs(0), SchedulingEvent::Tick);
 
     assert!(scheduler.has_pending());
-    assert_eq!(scheduler.next().unwrap().schedule(), Some(Event::Tick));
+    assert_eq!(
+        scheduler.next().unwrap().schedule(),
+        Some(SchedulingEvent::Tick)
+    );
 }
 
 #[test]
 fn test_schedule_after() {
     let mut scheduler = RealtimeScheduler::new();
 
-    scheduler.event_after(Duration::from_secs(2), Event::Tick);
+    scheduler.event_after(Duration::from_secs(2), SchedulingEvent::Tick);
 
     assert!(!scheduler.has_pending());
     assert!(scheduler.next().is_none());
@@ -27,6 +30,9 @@ fn test_schedule_after() {
     std::thread::sleep(scheduler.until_next().unwrap());
 
     assert!(scheduler.has_pending());
-    assert_eq!(scheduler.next().unwrap().schedule(), Some(Event::Tick));
+    assert_eq!(
+        scheduler.next().unwrap().schedule(),
+        Some(SchedulingEvent::Tick)
+    );
     assert!(scheduler.until_next().is_none());
 }


### PR DESCRIPTION
The server crate did not compile mostly due to artefacts from moving the Scheduler into its own module.

Currently it is a bit confusing when we are calling `next()` on the `Scheduler`.  We could potentially unify the `Iterator` trait s.t. the next scheduling event, be it from the `RealtimeScheduler` or the `FrontieredScheduler`, is returned. Right now only the `RealtimeScheduler` is used.
