### PR TITLE
Add README info about how to start the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ crate](https://docs.rs/log).  Logging at a specific level can be
 enabled by setting the `RUST_LOG` environment variable to
 `RUST_LOG=declarative_dataflow=<level>`.
 
+## Run
+
+To start the server. From the root of the project:
+
+```sh
+$ cd server
+$ cargo run
+```
+
+The first time you do this, the server will be compiled and then started.
+Subsequent runs will will start the server instantly.
+
 ## Documentation
 
 Crate documentation available on


### PR DESCRIPTION
Fixes #86 

Not at all sure you want this info here. :smile:

If the info is appropriate, then maybe also inform about which port it starts listening to. (Something I think should be showing in the ”Server running” message.)